### PR TITLE
feat: 增强 SSE 错误码识别，支持 1305/1310

### DIFF
--- a/internal/util/classifier.go
+++ b/internal/util/classifier.go
@@ -379,10 +379,10 @@ func classifySSEError(responseBody []byte) ErrorLevel {
 
 	// 根据error.type/code判断错误级别
 	switch errResp.ErrorType() {
-	case "api_error", "overloaded_error", "service_unavailable_error", "server_is_overloaded":
+	case "api_error", "overloaded_error", "service_unavailable_error", "server_is_overloaded", "1305":
 		// 上游服务错误或过载 → 渠道级冷却
 		return ErrorLevelChannel
-	case "rate_limit_error", "authentication_error", "invalid_request_error", "1308":
+	case "rate_limit_error", "authentication_error", "invalid_request_error", "1308", "1310":
 		// 限流/认证/请求错误 → Key级冷却
 		return ErrorLevelKey
 	default:
@@ -453,8 +453,9 @@ func ParseResetTimeFrom1308Error(responseBody []byte) (time.Time, bool) {
 		return time.Time{}, false
 	}
 
-	// 2. 检查是否为1308错误（优先使用type，如果为空则使用code）
-	if errResp.ErrorType() != "1308" {
+	// 2. 检查是否为1308或1310错误（优先使用type，如果为空则使用code）
+	errorType := errResp.ErrorType()
+	if errorType != "1308" && errorType != "1310" {
 		return time.Time{}, false
 	}
 

--- a/internal/util/classifier_1308_test.go
+++ b/internal/util/classifier_1308_test.go
@@ -44,6 +44,17 @@ func TestParseResetTimeFrom1308Error(t *testing.T) {
 			expectSuccess: true,
 			expectTime:    "2025-12-21 15:00:05",
 		},
+		{
+			name:          "1310周/月度限额耗尽",
+			responseBody:  `{"error":{"code":"1310","message":"Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-04-20 15:24:20"},"request_id":"..."}`,
+			expectSuccess: true,
+			expectTime:    "2026-04-20 15:24:20",
+		},
+		{
+			name:          "1310错误无时间",
+			responseBody:  `{"error":{"code":"1310","message":"Weekly/Monthly Limit Exhausted"}}`,
+			expectSuccess: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/util/classifier_test.go
+++ b/internal/util/classifier_test.go
@@ -691,6 +691,18 @@ func TestClassifySSEError(t *testing.T) {
 			reason:       "使用code字段的1308错误（非Anthropic格式）应触发Key级冷却",
 		},
 		{
+			name:         "1305_overloaded",
+			responseBody: []byte(`{"error":{"code":"1305","message":"The service may be temporarily overloaded"},"request_id":"..."}`),
+			expected:     ErrorLevelChannel,
+			reason:       "1305错误表示上游过载，应触发渠道级冷却",
+		},
+		{
+			name:         "1310_limit_exhausted",
+			responseBody: []byte(`{"error":{"code":"1310","message":"Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-04-20 15:24:20"},"request_id":"..."}`),
+			expected:     ErrorLevelKey,
+			reason:       "1310错误是Key配额问题，应触发Key级冷却",
+		},
+		{
 			name:         "unknown_error_type",
 			responseBody: []byte(`{"type":"error","error":{"type":"unknown_type","message":"未知错误"}}`),
 			expected:     ErrorLevelKey,


### PR DESCRIPTION
  - 1305 (Overloaded) → 渠道级冷却
  - 1310 (Limit Exhausted) → Key 级冷却 + 重置时间解析
  - 扩展 ParseResetTimeFrom1308Error 支持 1310 时间提取