### PR TITLE
fix(tokens): 修复令牌有效期无法改回永不过期

### DIFF
--- a/internal/app/admin_auth_tokens.go
+++ b/internal/app/admin_auth_tokens.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"log"
 	"net/http"
 	"strings"
@@ -17,6 +18,26 @@ import (
 // ============================================================================
 // API访问令牌管理 (Admin API)
 // ============================================================================
+
+type optionalInt64JSON struct {
+	set   bool
+	value *int64
+}
+
+func (v *optionalInt64JSON) UnmarshalJSON(data []byte) error {
+	v.set = true
+	if string(data) == "null" {
+		v.value = nil
+		return nil
+	}
+
+	var n int64
+	if err := json.Unmarshal(data, &n); err != nil {
+		return err
+	}
+	v.value = &n
+	return nil
+}
 
 // HandleListAuthTokens 列出所有API访问令牌（支持时间范围统计，2025-12扩展）
 // GET /admin/auth-tokens?range=today
@@ -217,12 +238,12 @@ func (s *Server) HandleUpdateAuthToken(c *gin.Context) {
 	}
 
 	var req struct {
-		Description       *string   `json:"description"`
-		IsActive          *bool     `json:"is_active"`
-		ExpiresAt         *int64    `json:"expires_at"`
-		AllowedModels     *[]string `json:"allowed_models"`      // nil=不更新，空数组=清除限制
-		AllowedChannelIDs *[]int64  `json:"allowed_channel_ids"` // nil=不更新，空数组=清除限制
-		CostLimitUSD      *float64  `json:"cost_limit_usd"`      // 费用上限（0=无限制）
+		Description       *string           `json:"description"`
+		IsActive          *bool             `json:"is_active"`
+		ExpiresAt         optionalInt64JSON `json:"expires_at"`
+		AllowedModels     *[]string         `json:"allowed_models"`      // nil=不更新，空数组=清除限制
+		AllowedChannelIDs *[]int64          `json:"allowed_channel_ids"` // nil=不更新，空数组=清除限制
+		CostLimitUSD      *float64          `json:"cost_limit_usd"`      // 费用上限（0=无限制）
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -251,8 +272,8 @@ func (s *Server) HandleUpdateAuthToken(c *gin.Context) {
 	if req.IsActive != nil {
 		token.IsActive = *req.IsActive
 	}
-	if req.ExpiresAt != nil {
-		token.ExpiresAt = req.ExpiresAt
+	if req.ExpiresAt.set {
+		token.ExpiresAt = req.ExpiresAt.value
 	}
 	if req.AllowedModels != nil {
 		token.AllowedModels = *req.AllowedModels

--- a/internal/app/admin_auth_tokens_update_delete_test.go
+++ b/internal/app/admin_auth_tokens_update_delete_test.go
@@ -145,6 +145,7 @@ func TestHandleUpdateAuthToken(t *testing.T) {
 		token2 := &model.AuthToken{
 			Token:             model.HashToken("plain-token-2"),
 			Description:       "keep-models",
+			ExpiresAt:         &expiresAt,
 			IsActive:          true,
 			AllowedModels:     []string{"keep-a", "keep-b"},
 			AllowedChannelIDs: []int64{101, 202},
@@ -172,11 +173,53 @@ func TestHandleUpdateAuthToken(t *testing.T) {
 		if updated.Description != "keep-models-updated" || updated.IsActive {
 			t.Fatalf("db state mismatch: desc=%q active=%v", updated.Description, updated.IsActive)
 		}
+		if updated.ExpiresAt == nil || *updated.ExpiresAt != expiresAt {
+			t.Fatalf("ExpiresAt=%v, want preserved %d", updated.ExpiresAt, expiresAt)
+		}
 		if len(updated.AllowedModels) != 2 || updated.AllowedModels[0] != "keep-a" || updated.AllowedModels[1] != "keep-b" {
 			t.Fatalf("AllowedModels=%v, want preserved values", updated.AllowedModels)
 		}
 		if len(updated.AllowedChannelIDs) != 2 || updated.AllowedChannelIDs[0] != 101 || updated.AllowedChannelIDs[1] != 202 {
 			t.Fatalf("AllowedChannelIDs=%v, want preserved values", updated.AllowedChannelIDs)
+		}
+	})
+
+	t.Run("clear expires at when null", func(t *testing.T) {
+		token3 := &model.AuthToken{
+			Token:       model.HashToken("plain-token-3"),
+			Description: "expires-to-never",
+			ExpiresAt:   &expiresAt,
+			IsActive:    true,
+		}
+		if err := store.CreateAuthToken(ctx, token3); err != nil {
+			t.Fatalf("CreateAuthToken token3 failed: %v", err)
+		}
+
+		c, w := newTestContext(t, newJSONRequestBytes(http.MethodPut, "/admin/auth-tokens/3", []byte(`{"expires_at":null}`)))
+		c.Params = gin.Params{{Key: "id", Value: "3"}}
+
+		server.HandleUpdateAuthToken(c)
+		if w.Code != http.StatusOK {
+			t.Fatalf("status=%d, want %d, body=%s", w.Code, http.StatusOK, w.Body.String())
+		}
+
+		type respData struct {
+			ExpiresAt *int64 `json:"expires_at"`
+		}
+		resp := mustParseAPIResponse[respData](t, w.Body.Bytes())
+		if !resp.Success {
+			t.Fatalf("success=false, error=%q", resp.Error)
+		}
+		if resp.Data.ExpiresAt != nil {
+			t.Fatalf("response ExpiresAt=%v, want nil", resp.Data.ExpiresAt)
+		}
+
+		updated, err := store.GetAuthToken(ctx, token3.ID)
+		if err != nil {
+			t.Fatalf("GetAuthToken token3 failed: %v", err)
+		}
+		if updated.ExpiresAt != nil {
+			t.Fatalf("ExpiresAt=%v, want nil", updated.ExpiresAt)
 		}
 	})
 }


### PR DESCRIPTION
## 变更说明
修复用户将令牌有效期改回“永不过期”时不生效的问题。

## 原因
更新令牌接口之前无法区分 expires_at 字段缺省和显式 null，导致旧过期时间被保留。

## 验证
- 已补充回归测试
- 已通过：go test -tags go_json ./internal/app -run TestHandleUpdateAuthToken -v