### PR TITLE
feat(web): 支持渠道优先级行内编辑

### DIFF
--- a/web/assets/css/channels.css
+++ b/web/assets/css/channels.css
@@ -643,11 +643,63 @@
     .ch-priority-row {
       display: flex;
       align-items: center;
-      justify-content: flex-start;
+      justify-content: center;
       width: 100%;
       gap: 4px;
       min-width: 0;
       line-height: 1.15;
+    }
+
+    .ch-priority-editor-wrap {
+      display: inline-block;
+      max-width: 100%;
+    }
+
+    .ch-priority-editor {
+      display: inline-flex;
+      align-items: center;
+      width: 56px;
+      height: 30px;
+      border: 1px solid var(--neutral-300);
+      border-radius: 8px;
+      background: #ffffff;
+      overflow: hidden;
+      box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.04);
+    }
+
+    .ch-priority-editor-wrap.is-saving {
+      opacity: 0.65;
+      pointer-events: none;
+    }
+
+    .ch-priority-input {
+      width: 56px;
+      height: 30px;
+      border: 0;
+      background: #ffffff;
+      color: var(--neutral-900);
+      font-size: 13px;
+      font-weight: 700;
+      line-height: 30px;
+      text-align: center;
+      font-variant-numeric: tabular-nums;
+      appearance: textfield;
+      -moz-appearance: textfield;
+    }
+
+    .ch-priority-input::-webkit-outer-spin-button,
+    .ch-priority-input::-webkit-inner-spin-button {
+      margin: 0;
+      -webkit-appearance: none;
+    }
+
+    .ch-priority-input:focus {
+      outline: 2px solid rgba(59, 130, 246, 0.22);
+      outline-offset: -2px;
+    }
+
+    .ch-priority-input.is-dirty {
+      background: #fffbeb;
     }
 
     .ch-priority-label {
@@ -2927,6 +2979,10 @@
       .channel-table .ch-col-priority .ch-priority-stack,
       .channel-table .ch-col-cost .cost-stack {
         margin-left: auto;
+      }
+
+      .channel-table .ch-col-priority .ch-priority-editor-wrap {
+        flex: 0 0 auto;
       }
 
       .channel-table .ch-col-last-success .ch-last-status {

--- a/web/assets/js/channels-actions.test.js
+++ b/web/assets/js/channels-actions.test.js
@@ -36,6 +36,19 @@ test('渠道卡片模板不再渲染已禁用文字徽章', () => {
   assert.doesNotMatch(template, /channels\.statusDisabled/);
 });
 
+test('渠道优先级列只保留行内数字输入', () => {
+  const renderSource = fs.readFileSync(path.join(__dirname, 'channels-render.js'), 'utf8');
+
+  assert.match(renderSource, /ch-priority-editor-wrap/);
+  assert.match(renderSource, /class="ch-priority-input"/);
+  assert.match(renderSource, /\/admin\/channels\/batch-priority/);
+  assert.match(css, /\.ch-priority-editor-wrap\s*\{/);
+  assert.match(css, /\.ch-priority-editor\s*\{/);
+  assert.doesNotMatch(renderSource, /data-action="priority-step"/);
+  assert.doesNotMatch(css, /\.ch-priority-controls\s*\{/);
+  assert.doesNotMatch(css, /\.ch-priority-step\s*\{/);
+});
+
 test('渠道卡片模板把启用开关放在独立列，操作列不再包含 toggle 按钮', () => {
   const templateMatch = html.match(/<template id="tpl-channel-card">[\s\S]*?<\/template>/);
   assert.ok(templateMatch, '缺少 tpl-channel-card 模板');

--- a/web/assets/js/channels-render.js
+++ b/web/assets/js/channels-render.js
@@ -14,6 +14,10 @@ function buildPriorityRow(rowClass, valueClass, value) {
   return `<div class="ch-priority-row ${rowClass}"><span class="${valueClass}">${value}</span></div>`;
 }
 
+const CHANNEL_PRIORITY_MIN = -99999;
+const CHANNEL_PRIORITY_MAX = 99999;
+let channelPrioritySaveTimers = new Map();
+
 function escapeChannelRefreshText(value) {
   if (value === null || value === undefined) return '';
   return String(value).replace(/[&<>"']/g, c => ({
@@ -181,12 +185,14 @@ function buildEffectivePriorityHtml(channel) {
   const basePriority = channel.priority;
   const priorityLabel = window.t('channels.table.priority');
   const healthLabel = window.t('channels.stats.healthScoreLabel');
+  const channelId = Number(channel.id) || 0;
+  const escapedPriorityLabel = escapeChannelRefreshText(priorityLabel);
+  const basePriorityValue = normalizeInlinePriorityValue(basePriority, 0);
+  const baseRow = buildPriorityEditorRow(channelId, basePriorityValue, escapedPriorityLabel);
 
   if (channel.effective_priority === undefined || channel.effective_priority === null) {
     const title = `${priorityLabel}: ${basePriority}`;
-    const rows = [
-      buildPriorityRow('ch-priority-base', 'ch-priority-value', basePriority)
-    ];
+    const rows = [baseRow];
     return `<div class="ch-priority-stack" title="${title.replace(/"/g, '&quot;')}">${rows.join('')}</div>`;
   }
 
@@ -214,11 +220,123 @@ function buildEffectivePriorityHtml(channel) {
     ? 'ch-priority-value ch-priority-health-good'
     : 'ch-priority-value ch-priority-health-bad';
 
-  const rows = [buildPriorityRow('ch-priority-base', baseValueClass, basePriority)];
+  const rows = [baseRow];
   if (!isConsistent) {
     rows.push(buildPriorityRow('ch-priority-health', healthValueClass, effPriority));
   }
   return `<div class="ch-priority-stack" title="${title.replace(/"/g, '&quot;')}">${rows.join('')}</div>`;
+}
+
+function normalizeInlinePriorityValue(value, fallback) {
+  const fallbackValue = Number.isFinite(Number(fallback)) ? Number(fallback) : 0;
+  const num = Number(value);
+  if (!Number.isFinite(num)) return Math.trunc(fallbackValue);
+  return Math.max(CHANNEL_PRIORITY_MIN, Math.min(CHANNEL_PRIORITY_MAX, Math.trunc(num)));
+}
+
+function buildPriorityEditorRow(channelId, priority, priorityLabel) {
+  const disabledAttr = channelId > 0 ? '' : ' disabled';
+  return `<div class="ch-priority-row ch-priority-base">
+    <div class="ch-priority-editor-wrap" data-channel-id="${channelId}">
+      <div class="ch-priority-editor">
+        <input class="ch-priority-input" type="number" min="${CHANNEL_PRIORITY_MIN}" max="${CHANNEL_PRIORITY_MAX}" step="1" value="${priority}" data-channel-id="${channelId}" data-original-priority="${priority}" aria-label="${priorityLabel}"${disabledAttr}>
+      </div>
+    </div>
+  </div>`;
+}
+
+function setInlinePrioritySaving(input, saving) {
+  const editorWrap = input && input.closest ? input.closest('.ch-priority-editor-wrap') : null;
+  if (!editorWrap) return;
+  editorWrap.classList.toggle('is-saving', saving);
+  editorWrap.querySelectorAll('button, input').forEach((el) => {
+    el.disabled = saving;
+  });
+}
+
+function updateLocalChannelPriority(channelId, priority) {
+  const updateList = (list) => {
+    if (!Array.isArray(list)) return;
+    list.forEach((channel) => {
+      if (Number(channel && channel.id) !== channelId) return;
+      const oldPriority = normalizeInlinePriorityValue(channel.priority, 0);
+      if (channel.effective_priority !== undefined && channel.effective_priority !== null) {
+        const effectiveOffset = Number(channel.effective_priority) - oldPriority;
+        if (Number.isFinite(effectiveOffset)) {
+          channel.effective_priority = priority + effectiveOffset;
+        }
+      }
+      channel.priority = priority;
+    });
+  };
+  if (typeof channels !== 'undefined') updateList(channels);
+  if (typeof filteredChannels !== 'undefined') updateList(filteredChannels);
+}
+
+async function saveInlineChannelPriority(input) {
+  if (!input) return;
+  const channelId = Number(input.dataset.channelId);
+  if (!Number.isFinite(channelId) || channelId <= 0) return;
+
+  const originalPriority = normalizeInlinePriorityValue(input.dataset.originalPriority, 0);
+  const nextPriority = normalizeInlinePriorityValue(input.value, originalPriority);
+  input.value = String(nextPriority);
+  if (nextPriority === originalPriority) {
+    input.classList.remove('is-dirty');
+    return;
+  }
+
+  try {
+    setInlinePrioritySaving(input, true);
+    await fetchDataWithAuth('/admin/channels/batch-priority', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ updates: [{ id: channelId, priority: nextPriority }] })
+    });
+
+    input.dataset.originalPriority = String(nextPriority);
+    input.classList.remove('is-dirty');
+    updateLocalChannelPriority(channelId, nextPriority);
+    if (typeof clearChannelsCache === 'function') clearChannelsCache();
+    if (typeof filterChannels === 'function') filterChannels();
+    if (window.showSuccess) window.showSuccess(window.t('channels.priorityUpdateSuccess'));
+  } catch (error) {
+    console.error('Update channel priority failed:', error);
+    input.value = String(originalPriority);
+    input.classList.remove('is-dirty');
+    if (window.showError) {
+      window.showError(error.message || window.t('channels.priorityUpdateFailed'));
+    }
+  } finally {
+    setInlinePrioritySaving(input, false);
+  }
+}
+
+function queueInlineChannelPrioritySave(input, delay = 500) {
+  if (!input) return;
+  const channelId = Number(input.dataset.channelId);
+  if (!Number.isFinite(channelId) || channelId <= 0) return;
+  input.classList.add('is-dirty');
+  const existingTimer = channelPrioritySaveTimers.get(channelId);
+  if (existingTimer) clearTimeout(existingTimer);
+  const timer = setTimeout(() => {
+    channelPrioritySaveTimers.delete(channelId);
+    saveInlineChannelPriority(input);
+  }, delay);
+  channelPrioritySaveTimers.set(channelId, timer);
+}
+
+function flushInlineChannelPrioritySave(input) {
+  if (!input) return;
+  const channelId = Number(input.dataset.channelId);
+  const existingTimer = channelPrioritySaveTimers.get(channelId);
+  if (existingTimer) {
+    clearTimeout(existingTimer);
+    channelPrioritySaveTimers.delete(channelId);
+  }
+  return saveInlineChannelPriority(input);
 }
 
 function inlineCooldownBadge(c) {
@@ -617,6 +735,31 @@ function initChannelEventDelegation() {
     if (typeof updateBatchChannelSelectionUI === 'function') {
       updateBatchChannelSelectionUI();
     }
+  });
+
+  container.addEventListener('input', (e) => {
+    const input = e.target.closest('.ch-priority-input');
+    if (!input) return;
+    queueInlineChannelPrioritySave(input);
+  });
+
+  container.addEventListener('keydown', (e) => {
+    const input = e.target.closest('.ch-priority-input');
+    if (!input) return;
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      flushInlineChannelPrioritySave(input);
+    } else if (e.key === 'Escape') {
+      const originalPriority = normalizeInlinePriorityValue(input.dataset.originalPriority, 0);
+      input.value = String(originalPriority);
+      input.classList.remove('is-dirty');
+    }
+  });
+
+  container.addEventListener('focusout', (e) => {
+    const input = e.target.closest('.ch-priority-input');
+    if (!input) return;
+    flushInlineChannelPrioritySave(input);
   });
 
   // 事件委托：处理所有渠道操作按钮

--- a/web/assets/js/channels-render.test.js
+++ b/web/assets/js/channels-render.test.js
@@ -13,6 +13,8 @@ function loadRenderSandbox(overrides = {}) {
         if (key === 'channels.table.priority') return '优先级';
         if (key === 'channels.stats.healthScoreLabel') return '健康度';
         if (key === 'channels.stats.successRate') return `成功率 ${params.rate}`;
+        if (key === 'channels.priorityUpdateSuccess') return '优先级已更新';
+        if (key === 'channels.priorityUpdateFailed') return '优先级更新失败';
         if (key === 'channels.stats.firstByte') return '首字';
         if (key === 'channels.stats.calls') return '调用';
         if (key === 'channels.table.lastSuccess') return '最后成功';
@@ -77,6 +79,11 @@ function loadRenderSandbox(overrides = {}) {
     humanizeMS(ms) {
       return `${ms}ms`;
     },
+    setTimeout(fn) {
+      fn();
+      return 1;
+    },
+    clearTimeout() {},
     console
   };
 
@@ -101,7 +108,7 @@ test('buildEffectivePriorityHtml 不渲染优先级和健康度标签', () => {
   });
 
   assert.ok(!html.includes('ch-priority-label'));
-  assert.ok(html.includes('>110<'));
+  assert.match(html, /class="ch-priority-input"[^>]*value="110"/);
   assert.ok(html.includes('>105<'));
 });
 
@@ -114,8 +121,23 @@ test('buildEffectivePriorityHtml 在健康度等于优先级时只显示一次�
   });
 
   assert.equal((html.match(/ch-priority-row/g) || []).length, 1);
-  assert.equal((html.match(/>100</g) || []).length, 1);
+  assert.match(html, /class="ch-priority-input"[^>]*value="100"/);
   assert.ok(!html.includes('ch-priority-health'));
+});
+
+test('buildEffectivePriorityHtml 渲染可直接编辑的优先级控件', () => {
+  const { buildEffectivePriorityHtml } = loadRenderHelpers();
+
+  const html = buildEffectivePriorityHtml({
+    id: 42,
+    priority: 7
+  });
+
+  assert.match(html, /ch-priority-editor-wrap/);
+  assert.match(html, /ch-priority-editor/);
+  assert.match(html, /class="ch-priority-input"[^>]*data-channel-id="42"[^>]*data-original-priority="7"/);
+  assert.doesNotMatch(html, /ch-priority-controls/);
+  assert.doesNotMatch(html, /data-action="priority-step"/);
 });
 
 test('buildChannelTimingHtml 渲染耗时和带单位的调用汇总', () => {
@@ -284,6 +306,46 @@ test('initChannelEventDelegation 允许表头全选 checkbox 触发可见渠道�
   listeners.change({ target: headerCheckbox });
 
   assert.equal(toggleCalls, 1);
+});
+
+test('initChannelEventDelegation 不会在 change 事件里保存行内优先级', () => {
+  const listeners = {};
+  const container = {
+    dataset: {},
+    addEventListener(type, handler) {
+      listeners[type] = handler;
+    }
+  };
+  let flushCalls = 0;
+  const input = {
+    closest(selector) {
+      return selector === '.ch-priority-input' ? this : null;
+    }
+  };
+
+  const { initChannelEventDelegation } = loadRenderSandbox({
+    document: {
+      getElementById(id) {
+        return id === 'channels-container' ? container : null;
+      },
+      addEventListener() {
+      }
+    },
+    toggleVisibleChannelsSelection() {
+    },
+    selectedChannelIds: new Set(),
+    normalizeSelectedChannelID(value) {
+      return value;
+    },
+    flushInlineChannelPrioritySave() {
+      flushCalls += 1;
+    }
+  });
+
+  initChannelEventDelegation();
+  listeners.change({ target: input });
+
+  assert.equal(flushCalls, 0);
 });
 
 test('buildProtocolTransformBadges 按完整协议集合渲染额外协议并去重', () => {

--- a/web/assets/locales/en.js
+++ b/web/assets/locales/en.js
@@ -1036,6 +1036,8 @@ window.I18N_LOCALES['en'] = {
   'channels.sortSaveSuccess': 'Sort order saved',
   'channels.sortNoChanges': 'No changes to save',
   'channels.sortSaveFailed': 'Failed to save sort order',
+  'channels.priorityUpdateSuccess': 'Priority updated',
+  'channels.priorityUpdateFailed': 'Failed to update priority',
   'channels.loadChannelsFailed': 'Unable to load channel list',
   'channels.channelAdded': 'Channel added',
   'channels.channelUpdated': 'Channel updated',

--- a/web/assets/locales/zh-CN.js
+++ b/web/assets/locales/zh-CN.js
@@ -1036,6 +1036,8 @@ window.I18N_LOCALES['zh-CN'] = {
   'channels.sortSaveSuccess': '排序已保存',
   'channels.sortNoChanges': '没有需要保存的排序',
   'channels.sortSaveFailed': '保存排序失败',
+  'channels.priorityUpdateSuccess': '优先级已更新',
+  'channels.priorityUpdateFailed': '优先级更新失败',
   'channels.loadChannelsFailed': '无法加载渠道列表',
   'channels.channelAdded': '渠道已添加',
   'channels.channelUpdated': '渠道已更新',


### PR DESCRIPTION
## 概要

支持在渠道列表中直接编辑优先级，同时保留健康度模式下的有效优先级展示。

## 为什么这样改

优先级是一个需要频繁微调的数值配置，直接在列表里输入指定值，比进入编辑流程或做相对调整更直接，也更符合实际使用场景。

## 改动内容

- 将优先级列改为可直接输入的数字框
- 支持列表内直接保存优先级
- 保留有效优先级展示
- 补充相关样式、文案和前端测试

## 验证

- `node --test web/assets/js/channels-render.test.js web/assets/js/channels-actions.test.js`