### PR TITLE
fix(url-state): cleanup orphaned records and sync disabled map on URL…

### DIFF
--- a/internal/app/admin_channels.go
+++ b/internal/app/admin_channels.go
@@ -770,10 +770,12 @@ func (s *Server) handleUpdateChannel(c *gin.Context, id int64) {
 		s.InvalidateAPIKeysCache(id)
 	}
 
-	// URL 更新后立即清理失效的 URLSelector 状态，避免旧URL状态长期残留。
+	// URL 更新后立即清理失效的 URL 状态（内存+数据库同步）
 	if s.urlSelector != nil {
 		s.urlSelector.PruneChannel(id, upd.GetURLs())
 	}
+	// 同步清理数据库中已移除URL的禁用状态记录
+	s.cleanupOrphanedURLStates(c.Request.Context(), id, upd.GetURLs())
 
 	RespondJSON(c, http.StatusOK, upd)
 }
@@ -795,6 +797,17 @@ func (s *Server) handleDeleteChannel(c *gin.Context, id int64) {
 	// 否则若后续以同 ID 重新创建渠道（显式主键路径，例如混合存储恢复），可能读到旧 keys。
 	s.InvalidateAPIKeysCache(id)
 	RespondJSON(c, http.StatusOK, gin.H{"id": id})
+}
+
+// cleanupOrphanedURLStates 清理数据库中已移除URL的禁用状态记录，失败仅警告不影响主流程
+func (s *Server) cleanupOrphanedURLStates(ctx context.Context, channelID int64, keepURLs []string) {
+	if s.store == nil {
+		return
+	}
+
+	if err := s.store.CleanupOrphanedURLStates(ctx, channelID, keepURLs); err != nil {
+		log.Printf("[WARN] 清理孤立URL状态失败 (channel=%d, urls=%d): %v", channelID, len(keepURLs), err)
+	}
 }
 
 // HandleDeleteAPIKey 删除渠道下的单个Key，并保持key_index连续

--- a/internal/app/admin_csv.go
+++ b/internal/app/admin_csv.go
@@ -240,6 +240,8 @@ func (s *Server) HandleImportChannelsCSV(c *gin.Context) {
 					continue
 				}
 				s.urlSelector.PruneChannel(channelID, cfg.GetURLs())
+				// 同步清理数据库中已移除URL的禁用状态记录
+				s.cleanupOrphanedURLStates(c.Request.Context(), channelID, cfg.GetURLs())
 			}
 		}
 	}

--- a/internal/app/url_selector.go
+++ b/internal/app/url_selector.go
@@ -185,6 +185,14 @@ func (s *URLSelector) PruneChannel(channelID int64, keepURLs []string) {
 			delete(s.requests, key)
 		}
 	}
+	for key := range s.disabled {
+		if key.channelID != channelID {
+			continue
+		}
+		if _, ok := keep[key.url]; !ok {
+			delete(s.disabled, key)
+		}
+	}
 }
 
 // RemoveChannel 移除指定渠道的全部 URL 状态。

--- a/internal/app/url_selector_test.go
+++ b/internal/app/url_selector_test.go
@@ -533,3 +533,27 @@ func TestURLSelector_ProbeURLs_DeduplicatesInFlightRequests(t *testing.T) {
 	closeRelease()
 	<-done1
 }
+
+func TestPruneChannel_DisabledMap(t *testing.T) {
+	sel := NewURLSelector()
+	channelID := int64(1)
+
+	// 禁用 url1
+	sel.DisableURL(channelID, "https://url1.com")
+	if !sel.IsDisabled(channelID, "https://url1.com") {
+		t.Fatalf("expected url1 to be disabled")
+	}
+
+	// 调用 PruneChannel 清理渠道，保留 url2（url1 应被清理）
+	sel.PruneChannel(channelID, []string{"https://url2.com"})
+
+	// 验证 url1 的禁用状态已被清理
+	if sel.IsDisabled(channelID, "https://url1.com") {
+		t.Fatalf("expected url1 disabled state to be pruned")
+	}
+
+	// 验证 url2 未被禁用
+	if sel.IsDisabled(channelID, "https://url2.com") {
+		t.Fatalf("expected url2 to not be disabled")
+	}
+}

--- a/internal/storage/hybrid_store.go
+++ b/internal/storage/hybrid_store.go
@@ -287,6 +287,20 @@ func (h *HybridStore) SetURLDisabled(ctx context.Context, channelID int64, url s
 	return nil
 }
 
+func (h *HybridStore) CleanupOrphanedURLStates(ctx context.Context, channelID int64, keepURLs []string) error {
+	// 先清理MySQL（主存储）
+	if err := h.mysql.CleanupOrphanedURLStates(ctx, channelID, keepURLs); err != nil {
+		return err
+	}
+
+	// 同步清理SQLite缓存（失败仅警告）
+	h.syncToSQLite("CleanupOrphanedURLStates", func() error {
+		return h.sqlite.CleanupOrphanedURLStates(ctx, channelID, keepURLs)
+	})
+
+	return nil
+}
+
 // === API Key Management ===
 
 func (h *HybridStore) GetAPIKeys(ctx context.Context, channelID int64) ([]*model.APIKey, error) {

--- a/internal/storage/sql/url_state.go
+++ b/internal/storage/sql/url_state.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -69,6 +70,40 @@ func (s *SQLStore) SetURLDisabled(ctx context.Context, channelID int64, url stri
 
 	if _, err := s.db.ExecContext(ctx, query, channelID, hash, url, disabledInt, now); err != nil {
 		return fmt.Errorf("upsert channel_url_states: %w", err)
+	}
+	return nil
+}
+
+// CleanupOrphanedURLStates 清理指定渠道中不再存在的URL的禁用状态记录
+func (s *SQLStore) CleanupOrphanedURLStates(ctx context.Context, channelID int64, keepURLs []string) error {
+	// 空 keepURLs 列表：删除该渠道的全部URL状态记录（渠道无URL场景）
+	if len(keepURLs) == 0 {
+		_, err := s.db.ExecContext(ctx,
+			`DELETE FROM channel_url_states WHERE channel_id = ?`,
+			channelID)
+		if err != nil {
+			return fmt.Errorf("delete all url states for channel %d: %w", channelID, err)
+		}
+		return nil
+	}
+
+	// 构建参数化查询：DELETE WHERE channel_id = ? AND url NOT IN (?,?,...)
+	args := make([]any, 0, len(keepURLs)+1)
+	args = append(args, channelID)
+
+	placeholders := make([]string, 0, len(keepURLs))
+	for _, url := range keepURLs {
+		placeholders = append(placeholders, "?")
+		args = append(args, url)
+	}
+
+	query := fmt.Sprintf(
+		`DELETE FROM channel_url_states WHERE channel_id = ? AND url NOT IN (%s)`,
+		strings.Join(placeholders, ", "))
+
+	_, err := s.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("cleanup orphaned url states for channel %d: %w", channelID, err)
 	}
 	return nil
 }

--- a/internal/storage/sql/url_state_test.go
+++ b/internal/storage/sql/url_state_test.go
@@ -1,0 +1,137 @@
+package sql_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"ccLoad/internal/model"
+	"ccLoad/internal/storage"
+)
+
+func TestCleanupOrphanedURLStates(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	store, err := storage.CreateSQLiteStore(filepath.Join(tmp, "test_url_state.db"))
+	if err != nil {
+		t.Fatalf("创建存储失败: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	now := time.Now()
+
+	// 创建测试渠道
+	channel := &model.Config{
+		ID:        1,
+		Name:      "test-channel",
+		URL:       "https://api1.example.com,https://api2.example.com,https://api3.example.com",
+		Enabled:   true,
+		CreatedAt: model.JSONTime{Time: now},
+		UpdatedAt: model.JSONTime{Time: now},
+	}
+	_, err = store.CreateConfig(ctx, channel)
+	if err != nil {
+		t.Fatalf("创建渠道失败: %v", err)
+	}
+
+	// 插入3条URL禁用状态记录
+	urls := []string{
+		"https://api1.example.com",
+		"https://api2.example.com",
+		"https://api3.example.com",
+	}
+	for _, url := range urls {
+		if err := store.SetURLDisabled(ctx, channel.ID, url, true); err != nil {
+			t.Fatalf("插入URL状态失败: %v", err)
+		}
+	}
+
+	t.Run("场景1：移除部分URL", func(t *testing.T) {
+		// keepURLs只保留api1，清理api2和api3
+		keepURLs := []string{"https://api1.example.com"}
+
+		if err := store.CleanupOrphanedURLStates(ctx, channel.ID, keepURLs); err != nil {
+			t.Fatalf("清理失败: %v", err)
+		}
+
+		// 验证：只保留api1记录
+		disabledURLs, err := store.LoadDisabledURLs(ctx)
+		if err != nil {
+			t.Fatalf("查询失败: %v", err)
+		}
+
+		channelURLs := disabledURLs[channel.ID]
+		if len(channelURLs) != 1 {
+			t.Errorf("期望保留1条记录，实际=%d", len(channelURLs))
+		}
+		if len(channelURLs) > 0 && channelURLs[0] != "https://api1.example.com" {
+			t.Errorf("期望保留api1，实际=%s", channelURLs[0])
+		}
+	})
+
+	t.Run("场景2：空列表清理全部", func(t *testing.T) {
+		// 先恢复3条记录
+		for _, url := range urls {
+			if err := store.SetURLDisabled(ctx, channel.ID, url, true); err != nil {
+				t.Fatalf("恢复记录失败: %v", err)
+			}
+		}
+
+		// keepURLs为空，清理全部
+		keepURLs := []string{}
+
+		if err := store.CleanupOrphanedURLStates(ctx, channel.ID, keepURLs); err != nil {
+			t.Fatalf("清理失败: %v", err)
+		}
+
+		// 验证：无记录残留
+		disabledURLs, err := store.LoadDisabledURLs(ctx)
+		if err != nil {
+			t.Fatalf("查询失败: %v", err)
+		}
+
+		channelURLs := disabledURLs[channel.ID]
+		if len(channelURLs) != 0 {
+			t.Errorf("期望清理全部记录，实际残留=%d", len(channelURLs))
+		}
+	})
+
+	t.Run("场景3：无变化", func(t *testing.T) {
+		// 先恢复2条记录
+		if err := store.SetURLDisabled(ctx, channel.ID, "https://api1.example.com", true); err != nil {
+			t.Fatalf("恢复记录失败: %v", err)
+		}
+		if err := store.SetURLDisabled(ctx, channel.ID, "https://api2.example.com", true); err != nil {
+			t.Fatalf("恢复记录失败: %v", err)
+		}
+
+		// keepURLs包含全部URL，无清理
+		keepURLs := []string{"https://api1.example.com", "https://api2.example.com"}
+
+		if err := store.CleanupOrphanedURLStates(ctx, channel.ID, keepURLs); err != nil {
+			t.Fatalf("清理失败: %v", err)
+		}
+
+		// 验证：2条记录仍然存在
+		disabledURLs, err := store.LoadDisabledURLs(ctx)
+		if err != nil {
+			t.Fatalf("查询失败: %v", err)
+		}
+
+		channelURLs := disabledURLs[channel.ID]
+		if len(channelURLs) != 2 {
+			t.Errorf("期望保留2条记录，实际=%d", len(channelURLs))
+		}
+	})
+
+	t.Run("场景4：不存在记录", func(t *testing.T) {
+		// 清理不存在记录的渠道（清理操作不影响）
+		nonExistentChannelID := int64(999)
+		keepURLs := []string{"https://api.example.com"}
+
+		if err := store.CleanupOrphanedURLStates(ctx, nonExistentChannelID, keepURLs); err != nil {
+			t.Fatalf("清理不存在渠道应该成功: %v", err)
+		}
+	})
+}

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -33,6 +33,7 @@ type Store interface {
 	// 持久化URL级运行态（当前仅记录手动禁用），重启后由URLSelector回填
 	LoadDisabledURLs(ctx context.Context) (map[int64][]string, error)
 	SetURLDisabled(ctx context.Context, channelID int64, url string, disabled bool) error
+	CleanupOrphanedURLStates(ctx context.Context, channelID int64, keepURLs []string) error
 
 	// === API Key Management ===
 	GetAPIKeys(ctx context.Context, channelID int64) ([]*model.APIKey, error)


### PR DESCRIPTION
… change

修复渠道URL变更时状态清理的两个bug：

1. 数据库孤立数据清理
   - 新增 CleanupOrphanedURLStates() 方法清理已移除URL的禁用记录
   - 渠道更新和CSV导入后同步清理数据库，防止孤立数据积累
   - HybridStore双写清理（MySQL成功即成功，SQLite失败仅警告）

2. 内存状态同步修复
   - PruneChannel()方法遗漏清理disabled map，导致内存与数据库不一致
   - 新增清理逻辑，确保已移除URL的禁用状态从内存同步删除
   - 验证：url1禁用后改为url2，url2不会继承url1的禁用状态

改动文件：
- Store接口新增清理方法（store.go）
- SQLStore/HybridStore实现清理逻辑（url_state.go, hybrid_store.go）
- 渠道更新/CSV导入集成清理调用（admin_channels.go, admin_csv.go）
- URLSelector内存状态同步修复（url_selector.go）
- 新增单元测试覆盖全部场景（url_state_test.go, url_selector_test.go）

测试验证：
- TestCleanupOrphanedURLStates: 4场景全通过（部分清理/空列表/无变化/不存在）
- TestPruneChannel_DisabledMap: 内存同步验证通过
- 回归测试：23个URLSelector测试+全量storage测试通过