### PR TITLE
修复.env的密码变量无法传递到docker.yml的问题

### DIFF
--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -21,7 +21,7 @@ services:
       - SQLITE_PATH=/app/data/ccload.db
       - GIN_MODE=release
       # 必填：未设置将无法启动
-      - CCLOAD_PASS=${CCLOAD_PASS}
+      - CCLOAD_PASS=${CCLOAD_PASS:-your_admin_password}
       # 可选：启动时预置 API 访问令牌，格式 token 或 token|描述，逗号分隔
       # - CCLOAD_API_TOKENS=token1|production,token2|development
       # API访问令牌也可通过Web界面管理: http://localhost:8080/web/tokens.html

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -21,7 +21,7 @@ services:
       - SQLITE_PATH=/app/data/ccload.db
       - GIN_MODE=release
       # 必填：未设置将无法启动
-      - CCLOAD_PASS=your_admin_password
+      - CCLOAD_PASS=${CCLOAD_PASS}
       # 可选：启动时预置 API 访问令牌，格式 token 或 token|描述，逗号分隔
       # - CCLOAD_API_TOKENS=token1|production,token2|development
       # API访问令牌也可通过Web界面管理: http://localhost:8080/web/tokens.html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - SQLITE_PATH=/app/data/ccload.db
       - GIN_MODE=release
       # 必填：未设置将无法启动
-      - CCLOAD_PASS=${CCLOAD_PASS}
+      - CCLOAD_PASS=${CCLOAD_PASS:-your_admin_password}
       # 可选：启动时预置 API 访问令牌，格式 token 或 token|描述，逗号分隔
       # - CCLOAD_API_TOKENS=token1|production,token2|development
       - TZ=Asia/Shanghai

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - SQLITE_PATH=/app/data/ccload.db
       - GIN_MODE=release
       # 必填：未设置将无法启动
-      - CCLOAD_PASS=your_admin_password
+      - CCLOAD_PASS=${CCLOAD_PASS}
       # 可选：启动时预置 API 访问令牌，格式 token 或 token|描述，逗号分隔
       # - CCLOAD_API_TOKENS=token1|production,token2|development
       - TZ=Asia/Shanghai


### PR DESCRIPTION
docker yml里把CCLOAD_PASS写死了，导致如果按照readme中说的复制.env在里面改变量，实际上是无效的