### PR TITLE
fix: 抽统一函数disableResponseWriteTimeout, 统一流式和非流式行为, 修复非流式调用在最后写回响应时被Go…

### DIFF
--- a/internal/app/proxy_forward.go
+++ b/internal/app/proxy_forward.go
@@ -49,6 +49,13 @@ func (rc *onceCloseReadCloser) Close() error {
 	return closeErr
 }
 
+func disableResponseWriteTimeout(w http.ResponseWriter, requestKind string) {
+	rc := http.NewResponseController(w)
+	if err := rc.SetWriteDeadline(time.Time{}); err != nil {
+		log.Printf("[WARN] 无法禁用%s请求的 WriteTimeout: %v", requestKind, err)
+	}
+}
+
 // prependToBody 将前缀数据合并到resp.Body（用于恢复已探测的数据）
 func prependToBody(resp *http.Response, prefix []byte) {
 	resp.Body = readerWithCloser{
@@ -703,10 +710,9 @@ func (s *Server) handleSuccessResponse(
 	// [FIX] 流式请求：禁用 WriteTimeout，避免长时间流被服务器自己切断
 	// Go 1.20+ http.ResponseController 支持动态调整 WriteDeadline
 	if reqCtx.isStreaming {
-		rc := http.NewResponseController(w)
-		if err := rc.SetWriteDeadline(time.Time{}); err != nil {
-			log.Printf("[WARN] 无法禁用流式请求的 WriteTimeout: %v", err)
-		}
+		disableResponseWriteTimeout(w, "流式")
+	} else {
+		disableResponseWriteTimeout(w, "非流式")
 	}
 
 	streamWriter := w
@@ -855,6 +861,9 @@ func (s *Server) handleTranslatedNonStreamSuccessResponse(
 	translatedHeader := resp.Header.Clone()
 	translatedHeader.Set("Content-Type", "application/json")
 	translatedHeader.Del("Content-Encoding")
+
+	disableResponseWriteTimeout(w, "非流式")
+
 	filterAndWriteResponseHeaders(w, translatedHeader)
 	w.WriteHeader(resp.StatusCode)
 	_, _ = w.Write(translatedBody)
@@ -884,10 +893,7 @@ func (s *Server) handleTranslatedStreamSuccessResponse(
 	readStats *streamReadStats,
 	observer *ForwardObserver,
 ) (*fwResult, float64, error) {
-	rc := http.NewResponseController(w)
-	if err := rc.SetWriteDeadline(time.Time{}); err != nil {
-		log.Printf("[WARN] 无法禁用流式请求的 WriteTimeout: %v", err)
-	}
+	disableResponseWriteTimeout(w, "流式")
 
 	deferredWriter := newDeferredResponseWriter(w)
 	filterAndWriteResponseHeaders(deferredWriter, resp.Header)

--- a/internal/app/server_misc_test.go
+++ b/internal/app/server_misc_test.go
@@ -16,6 +16,45 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+type deadlineRecorderResponseWriter struct {
+	header         http.Header
+	writeDeadline  time.Time
+	deadlineCalled bool
+}
+
+func (w *deadlineRecorderResponseWriter) Header() http.Header {
+	if w.header == nil {
+		w.header = make(http.Header)
+	}
+	return w.header
+}
+
+func (w *deadlineRecorderResponseWriter) Write(data []byte) (int, error) {
+	return len(data), nil
+}
+
+func (w *deadlineRecorderResponseWriter) WriteHeader(_ int) {}
+
+func (w *deadlineRecorderResponseWriter) SetWriteDeadline(t time.Time) error {
+	w.deadlineCalled = true
+	w.writeDeadline = t
+	return nil
+}
+
+func TestDisableResponseWriteTimeoutClearsDeadline(t *testing.T) {
+	t.Parallel()
+
+	w := &deadlineRecorderResponseWriter{}
+	disableResponseWriteTimeout(w, "非流式")
+
+	if !w.deadlineCalled {
+		t.Fatal("SetWriteDeadline was not called")
+	}
+	if !w.writeDeadline.IsZero() {
+		t.Fatalf("writeDeadline=%v, want zero time", w.writeDeadline)
+	}
+}
+
 func TestServer_SetupRoutes_CORSPreflightBypassesAuth(t *testing.T) {
 	srv := newInMemoryServer(t)
 


### PR DESCRIPTION
fix: 抽统一函数disableResponseWriteTimeout, 统一流式和非流式行为, 修复非流式调用在最后写回响应时被Go的http.Server.WriteTimeout截断的问题

为什么要改这里：
我发现我在通过ccload调用模型时，长时间的非流式请求会失败。我发现问题发生在ccload写回客户端时，进而发现问题根因在于Go HTTP Server的WriteTimeout。即使在设置里将超时设置为0，也不会生效