### PR TITLE
fix(sse): 兼容仅发 data 行、不带 event: error 的上游错误帧

### DIFF
--- a/internal/app/proxy_sse_parser.go
+++ b/internal/app/proxy_sse_parser.go
@@ -458,9 +458,13 @@ func (p *sseUsageParser) parseEvent(eventType, data string) error {
 	// 方案：改为黑名单模式 - 只过滤已知无用事件，其他都尝试解析
 
 	// [WARN] 特殊处理：error事件（记录日志 + 存储错误体用于后续冷却处理）
-	if eventType == "error" {
+	// [PATCH] 兼容不规范上游：部分上游（如 sub2api）只发 `data: {"type":"error",...}`
+	// 而不带 `event: error` 行，导致 eventType 为空、错误帧漏判被当成正常输出，
+	// 最终记成 200/0token 假成功且不重试。这里增加 JSON body 回退检测，
+	// 与 isHeartbeatEvent 的 JSON 回退对称。
+	if eventType == "error" || isErrorPayload(data) {
 		log.Printf("[WARN]  [SSE错误事件] 上游返回error事件: %s", data)
-		// [INFO] 新增：存储错误事件的完整JSON（用于流结束后触发冷却逻辑）
+		// [INFO] 存储错误事件的完整JSON（用于流结束后触发冷却逻辑）
 		p.lastError = []byte(data)
 		return nil // 不解析usage，避免误判
 	}
@@ -565,6 +569,33 @@ func isHeartbeatEvent(eventType, data string) bool {
 		Type string `json:"type"`
 	}
 	return json.Unmarshal([]byte(data), &event) == nil && event.Type == "ping"
+}
+
+// [PATCH] isErrorPayload 检测 data 字段本身是否为一个 error 事件 JSON。
+// 用于兼容只发 `data: {"type":"error",...}` 而不带 `event: error` 行的不规范上游。
+// 判定依据（任一成立）：
+//   - 顶层 type == "error"（Anthropic 风格: {"type":"error","error":{...}}）
+//   - 顶层存在非空 error 对象（其他聚合站风格: {"error":{...}}）
+func isErrorPayload(data string) bool {
+	if data == "" {
+		return false
+	}
+	var event struct {
+		Type  string          `json:"type"`
+		Error json.RawMessage `json:"error"`
+	}
+	if json.Unmarshal([]byte(data), &event) != nil {
+		return false
+	}
+	if event.Type == "error" {
+		return true
+	}
+	// error 字段存在且为非空的 JSON 对象（排除 null / 空对象 / 空串）
+	trimmed := strings.TrimSpace(string(event.Error))
+	if trimmed == "" || trimmed == "null" || trimmed == "{}" {
+		return false
+	}
+	return strings.HasPrefix(trimmed, "{")
 }
 
 func (p *jsonUsageParser) Feed(data []byte) error {

--- a/internal/app/proxy_sse_parser_test.go
+++ b/internal/app/proxy_sse_parser_test.go
@@ -130,6 +130,55 @@ func TestSSEUsageParser_StreamOutputIgnoresHeartbeat(t *testing.T) {
 	}
 }
 
+// [PATCH] TestSSEUsageParser_JSONOnlyErrorFrame 复现不规范上游 bug：
+// 上游只发 `data: {"type":"error",...}` 而不带 `event: error` 行（如 sub2api）。
+// 修复前：errorType 为空 → 漏判 → hasStreamOutput=true、lastError=nil → 200/0token 假成功不重试。
+// 修复后：isErrorPayload 兜底识别 → lastError 被设置、不计为流输出 → 触发现有重试逻辑。
+func TestSSEUsageParser_JSONOnlyErrorFrame(t *testing.T) {
+	parser := newSSEUsageParser("anthropic")
+	// 先来几个 ping，再来一个无 event 行的 JSON error 帧
+	stream := "data: {\"type\": \"ping\"}\n\n" +
+		"data: {\"type\": \"ping\"}\n\n" +
+		"data: {\"type\":\"error\",\"error\":{\"type\":\"rate_limit_error\",\"message\":\"Concurrency limit exceeded for account, please retry later\"}}\n\n"
+	if err := parser.Feed([]byte(stream)); err != nil {
+		t.Fatalf("Feed失败: %v", err)
+	}
+	if parser.HasStreamOutput() {
+		t.Fatalf("JSON-only error frame must not count as stream output")
+	}
+	if parser.GetLastError() == nil {
+		t.Fatalf("JSON-only error frame must be captured as lastError for retry")
+	}
+}
+
+// [PATCH] TestSSEUsageParser_JSONOnlyErrorFrameNestedOnly 覆盖只有 error 对象、无顶层 type 的格式。
+func TestSSEUsageParser_JSONOnlyErrorFrameNestedOnly(t *testing.T) {
+	parser := newSSEUsageParser("openai")
+	if err := parser.Feed([]byte("data: {\"error\":{\"message\":\"upstream boom\",\"type\":\"server_error\"}}\n\n")); err != nil {
+		t.Fatalf("Feed失败: %v", err)
+	}
+	if parser.GetLastError() == nil {
+		t.Fatalf("nested error object must be captured as lastError")
+	}
+}
+
+// [PATCH] TestSSEUsageParser_NormalContentNotMisflaggedAsError 确保正常内容不被误判为 error。
+func TestSSEUsageParser_NormalContentNotMisflaggedAsError(t *testing.T) {
+	parser := newSSEUsageParser("anthropic")
+	// 正常文本增量 + 一个 error 字段为 null 的帧，都不应被判成 error
+	stream := "data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"hi\"}}\n\n" +
+		"data: {\"type\":\"message_delta\",\"error\":null,\"usage\":{\"output_tokens\":5}}\n\n"
+	if err := parser.Feed([]byte(stream)); err != nil {
+		t.Fatalf("Feed失败: %v", err)
+	}
+	if parser.GetLastError() != nil {
+		t.Fatalf("normal content must not be flagged as error, got: %s", parser.GetLastError())
+	}
+	if !parser.HasStreamOutput() {
+		t.Fatalf("normal content delta must count as stream output")
+	}
+}
+
 // ============================================================================
 // 边界测试：分块读取（真实SSE流场景）
 // ============================================================================


### PR DESCRIPTION
## 问题

部分上游（如基于 sub2api 的中转）在 HTTP 200 的 SSE 流中，错误帧只发 `data:` 行而**不带 `event: error` 行**，例如：

```
data: {"type": "ping"}
data: {"type": "ping"}
data: {"type":"error","error":{"type":"rate_limit_error","message":"Concurrency limit exceeded for account, please retry later"}}
```

这违反 Anthropic SSE 规范（规范要求 `event: error\ndata: {...}`），但现实中确有上游这么发。

## 现状（bug）

`parseEvent` 只在 `eventType == "error"` 时存 `lastError`：

```go
if eventType == "error" {   // eventType 来自 "event:" 行
    p.lastError = []byte(data)
    return nil
}
...
p.hasStreamOutput = true     // 无 event 行的 error 帧掉到这里，被当成正常输出
```

由于这类帧没有 `event:` 行，`eventType` 为空字符串，错误帧被误判为正常内容：`hasStreamOutput=true`、`lastError=nil`。

后果：
- 记为 **200 成功、0 input/0 output token**
- `SSEErrorEvent` 为 nil → 不触发任何 Key/渠道级冷却与重试
- 客户端（如 Claude Code）只收到 ping + 一个 error JSON，没有 `message_start`/content → 报 `Stream ended without receiving any events`，且不重试

## 修复

与现有 `isHeartbeatEvent` 的 JSON 回退对称，新增 `isErrorPayload(data)` 兜底：当 `data` 本身是 error JSON 时也识别为 error 帧。

```go
if eventType == "error" || isErrorPayload(data) {
    ...
    p.lastError = []byte(data)
    return nil
}
```

`isErrorPayload` 判定（任一成立）：
- 顶层 `type == "error"`（Anthropic 风格 `{"type":"error","error":{...}}`）
- 顶层存在非空 `error` 对象（其他聚合站风格 `{"error":{...}}`）

识别后即接入既有逻辑：`classifySSEError` 将 `rate_limit_error` 判为 Key 级 → 触发换 Key/渠道重试；因响应尚未提交（deferredWriter 未 commit），重试对客户端透明。

## 安全性

`isErrorPayload` 为白名单式：仅在 JSON 确有 `type:"error"` 或非空 `error` 对象时返回 true。新增测试 `TestSSEUsageParser_NormalContentNotMisflaggedAsError` 验证正常文本增量、`error:null` 等帧不会被误判。

## 测试

新增 3 个用例并全部通过：
- `TestSSEUsageParser_JSONOnlyErrorFrame`：复现 ping + 无 event 行的 error 帧场景
- `TestSSEUsageParser_JSONOnlyErrorFrameNestedOnly`：仅含 `error` 对象、无顶层 type
- `TestSSEUsageParser_NormalContentNotMisflaggedAsError`：确保正常内容不被误判

`go test -tags sonic ./internal/app/...` 全部通过（44 + 3）。`go vet` 干净。