### PR TITLE
fix: add MiniMax-M3 pricing

### DIFF
--- a/internal/util/cost_calculator.go
+++ b/internal/util/cost_calculator.go
@@ -579,6 +579,7 @@ var basePricing = map[string]ModelPricing{
 	"minimax-m2.1":   {InputPrice: 0.29, OutputPrice: 0.95, CacheReadPrice: 0.03, HasCacheReadPrice: true},
 	"minimax-m2.5":   {InputPrice: 0.15, OutputPrice: 0.90, CacheReadPrice: 0.027, HasCacheReadPrice: true},
 	"minimax-m2.7":   {InputPrice: 0.279, OutputPrice: 1.20, CacheReadPrice: 0.059, HasCacheReadPrice: true},
+	"minimax-m3":     {InputPrice: 0.60, OutputPrice: 2.40, CacheReadPrice: 0.12, HasCacheReadPrice: true},
 
 	// ========== 美团 LongCat 模型 ==========
 	// 来源: https://api.pricepertoken.com/api/provider-pricing-history/?provider=meituan
@@ -1240,7 +1241,7 @@ var fuzzyPrefixes = []string{
 	"grok-code-fast-1", "grok-vision-beta",
 
 	// MiniMax模型
-	"minimax-m2.7", "minimax-m2.5", "minimax-m2.1", "minimax-m2-her", "minimax-m2", "minimax-m1", "minimax-01",
+	"minimax-m3", "minimax-m2.7", "minimax-m2.5", "minimax-m2.1", "minimax-m2-her", "minimax-m2", "minimax-m1", "minimax-01",
 
 	// 美团 LongCat模型（长前缀优先）
 	"longcat-flash-chat-2602-exp", "longcat-flash-chat:free", "longcat-flash-chat",

--- a/internal/util/cost_calculator_test.go
+++ b/internal/util/cost_calculator_test.go
@@ -948,6 +948,7 @@ func TestCalculateCost_MiniMaxModels(t *testing.T) {
 		{"minimax-m1", 0.40, 2.20},
 		{"minimax-m2", 0.255, 1.00},
 		{"minimax-m2.1", 0.29, 0.95},
+		{"minimax-m3", 0.60, 2.40},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Reason: 静态定价目录 basePricing 已收录 MiniMax-M1 到 M2.7 但缺 M3,导致按 MiniMax-M3 转发的请求成本计为零。

## Summary
- Add MiniMax-M3 token and cache-read pricing to the static cost catalog.
- Include MiniMax-M3 in fuzzy prefix matching so versioned M3 model names resolve correctly.
- Extend MiniMax cost calculator coverage with an M3 test case.

## Test plan
- `go test ./internal/util`