### PR TITLE
feature(channels.css): 增大APK keys区域table表格的可视区域行数, 从原有的最大2行改为11行.

### DIFF
--- a/web/assets/css/channels.css
+++ b/web/assets/css/channels.css
@@ -242,6 +242,10 @@
       scrollbar-color: rgba(100, 116, 139, 0.45) transparent;
     }
 
+    #channelModal .inline-table-container:has(.inline-key-table) {
+      --channel-editor-table-visible-rows: 11;
+    }
+
     #channelModal .inline-table-container::-webkit-scrollbar {
       width: 6px;
       height: 6px;


### PR DESCRIPTION
# 背景
目前遇到在一个渠道下管理20个key的场景, 目前最多只展示2行key, 在调整顺序和查看渠道下有哪些key时非常不方便

# 改动
web\assets\css\channels.css
- 新增样式配置: 在渠道编辑弹窗的api key区域下的table中生效, 将显示的最大行数改为11.

# 兼容性
经过测试, key的数量>2时, pc端可正常展示多行key, 最多展示11行, 超出11行展示滚动条.
移动端不受影响.
