### PR TITLE
fix: finish Responses streams after response.completed

### DIFF
--- a/internal/app/proxy_forward.go
+++ b/internal/app/proxy_forward.go
@@ -270,23 +270,51 @@ func streamAndParseResponse(
 			return nil
 		}
 	}
+	copySSE := func(stream io.Reader, parser *sseUsageParser) error {
+		feed := makeFeed(parser)
+		if channelType == util.ChannelTypeCodex {
+			// Responses has an explicit terminal event. Some compatible upstreams emit it
+			// but keep the HTTP body open. Track only bounded framing state while preserving
+			// chunk-by-chunk forwarding, then stop after the terminal event is written/flushed.
+			detector := newResponsesCompletedDetector()
+			return streamCopySSE(ctx, stream, w, func(data []byte) error {
+				boundary, completed := detector.TerminalBoundary(data)
+				feedData := data
+				if completed {
+					// The usage parser currently tokenizes LF-delimited lines. Set completion
+					// before beforeWrite runs so valid bare-CR framing commits deferred output.
+					parser.streamComplete = true
+					feedData = data[:boundary]
+				}
+				hookErr := feed(feedData)
+				if errors.Is(hookErr, errAbortStreamBeforeWrite) {
+					return hookErr
+				}
+				if completed {
+					return &stopStreamAfterWriteError{writeBytes: boundary}
+				}
+				return hookErr
+			})
+		}
+		return streamCopySSE(ctx, stream, w, feed)
+	}
 
 	// SSE流式响应
 	if strings.Contains(contentType, "text/event-stream") {
 		parser := newSSEUsageParser(channelType)
-		streamErr := streamCopySSE(ctx, body, w, makeFeed(parser))
+		streamErr := copySSE(body, parser)
 		return parser, streamErr
 	}
 
 	// 非标准SSE场景：上游以text/plain发送SSE事件
 	if strings.Contains(contentType, "text/plain") && isStreaming {
 		reader := bufio.NewReader(body)
-		probe, _ := reader.Peek(SSEProbeSize)
+		_, isSSE := peekUntilSSEOrLimit(reader, SSEProbeSize)
 		streamBody := readerWithCloser{Reader: reader, Closer: body}
 
-		if looksLikeSSE(probe) {
+		if isSSE {
 			parser := newSSEUsageParser(channelType)
-			sseErr := streamCopySSE(ctx, streamBody, w, makeFeed(parser))
+			sseErr := copySSE(streamBody, parser)
 			return parser, sseErr
 		}
 		parser := newJSONUsageParser(channelType)
@@ -751,7 +779,7 @@ func (s *Server) handleSuccessResponse(
 			if parser.GetLastError() != nil {
 				return errAbortStreamBeforeWrite
 			}
-			if parser.HasStreamOutput() {
+			if parser.HasStreamOutput() || parser.IsStreamComplete() {
 				return deferredWriter.Commit()
 			}
 			return nil
@@ -1008,6 +1036,23 @@ func isHTTP2StreamCloseError(err error) bool {
 		strings.Contains(errStr, "stream error:")
 }
 
+// peekUntilSSEOrLimit incrementally peeks so a short, still-open text/plain SSE stream
+// can be classified as soon as event/data prefixes are available instead of waiting for EOF.
+func peekUntilSSEOrLimit(reader *bufio.Reader, limit int) ([]byte, bool) {
+	var probe []byte
+	for n := 1; n <= limit; n++ {
+		current, err := reader.Peek(n)
+		probe = current
+		if looksLikeSSE(current) {
+			return current, true
+		}
+		if err != nil {
+			return current, false
+		}
+	}
+	return probe, false
+}
+
 // looksLikeSSE 粗略判断文本内容是否包含 SSE 事件结构
 func looksLikeSSE(data []byte) bool {
 	// 同时包含 event: 与 data: 行。必须是行前缀，避免普通JSON字符串里的
@@ -1016,14 +1061,18 @@ func looksLikeSSE(data []byte) bool {
 	hasData := false
 	for len(data) > 0 {
 		line := data
-		if idx := bytes.IndexByte(data, '\n'); idx >= 0 {
+		if idx := bytes.IndexAny(data, "\r\n"); idx >= 0 {
 			line = data[:idx]
-			data = data[idx+1:]
+			consume := idx + 1
+			if data[idx] == '\r' && consume < len(data) && data[consume] == '\n' {
+				consume++
+			}
+			data = data[consume:]
 		} else {
 			data = nil
 		}
 
-		line = bytes.TrimLeft(line, " \t\r")
+		line = bytes.TrimLeft(line, " 	")
 		if bytes.HasPrefix(line, []byte("event:")) {
 			hasEvent = true
 		}

--- a/internal/app/proxy_stream.go
+++ b/internal/app/proxy_stream.go
@@ -9,7 +9,125 @@ import (
 	"net/http"
 )
 
-var errAbortStreamBeforeWrite = errors.New("abort stream before first client write")
+var (
+	errAbortStreamBeforeWrite = errors.New("abort stream before first client write")
+	errStopStreamAfterWrite   = errors.New("stop stream after current client write")
+)
+
+type stopStreamAfterWriteError struct {
+	writeBytes int
+}
+
+func (e *stopStreamAfterWriteError) Error() string {
+	return errStopStreamAfterWrite.Error()
+}
+
+func (e *stopStreamAfterWriteError) Unwrap() error {
+	return errStopStreamAfterWrite
+}
+
+// maxTrackedSSELineBytes bounds the framing state; response.completed event lines are tiny.
+const maxTrackedSSELineBytes = 256
+
+// responsesCompletedDetector recognizes a complete Responses terminal SSE event while
+// retaining only bounded line state. Payload bytes continue through the normal chunk copier.
+type responsesCompletedDetector struct {
+	line              []byte
+	lineTooLong       bool
+	eventType         string
+	skipLF            bool
+	preferCRLF        bool
+	pendingTerminalCR bool
+}
+
+func newResponsesCompletedDetector() *responsesCompletedDetector {
+	return &responsesCompletedDetector{line: make([]byte, 0, maxTrackedSSELineBytes)}
+}
+
+func (d *responsesCompletedDetector) Feed(data []byte) bool {
+	_, completed := d.TerminalBoundary(data)
+	return completed
+}
+
+// TerminalBoundary returns the byte offset immediately after the terminal event delimiter.
+func (d *responsesCompletedDetector) TerminalBoundary(data []byte) (int, bool) {
+	if d.pendingTerminalCR {
+		d.pendingTerminalCR = false
+		if len(data) > 0 && data[0] == '\n' {
+			return 1, true
+		}
+		return 0, true
+	}
+
+	for i, b := range data {
+		if d.skipLF {
+			d.skipLF = false
+			if b == '\n' {
+				d.preferCRLF = true
+				continue
+			}
+			d.preferCRLF = false
+		}
+
+		switch b {
+		case '\r':
+			if d.finishLine() {
+				end := i + 1
+				if end < len(data) {
+					if data[end] == '\n' {
+						return end + 1, true
+					}
+					return end, true
+				}
+				if d.preferCRLF {
+					d.pendingTerminalCR = true
+					return 0, false
+				}
+				return end, true
+			}
+			d.skipLF = true
+		case '\n':
+			d.preferCRLF = false
+			if d.finishLine() {
+				return i + 1, true
+			}
+		default:
+			if len(d.line) < maxTrackedSSELineBytes {
+				d.line = append(d.line, b)
+			} else {
+				d.lineTooLong = true
+			}
+		}
+	}
+	return 0, false
+}
+
+func (d *responsesCompletedDetector) finishLine() bool {
+	defer func() {
+		d.line = d.line[:0]
+		d.lineTooLong = false
+	}()
+
+	if !d.lineTooLong && len(d.line) == 0 {
+		completed := d.eventType == "response.completed"
+		d.eventType = ""
+		return completed
+	}
+	if d.lineTooLong {
+		if bytes.HasPrefix(d.line, []byte("event:")) {
+			d.eventType = ""
+		}
+		return false
+	}
+	if after, ok := bytes.CutPrefix(d.line, []byte("event:")); ok {
+		// SSE removes at most one leading ASCII space after the colon.
+		if len(after) > 0 && after[0] == ' ' {
+			after = after[1:]
+		}
+		d.eventType = string(after)
+	}
+	return false
+}
 
 // ============================================================================
 // 流式传输数据结构
@@ -70,6 +188,8 @@ func streamCopyWithBufferSize(ctx context.Context, src io.Reader, dst http.Respo
 
 		n, err := src.Read(buf)
 		if n > 0 {
+			stopAfterWrite := false
+			writeBytes := n
 			// [FIX] 2026-01: 先 Feed 数据到 parser，再写入客户端
 			// 原因：即使写入失败（客户端断开），也需要检测流结束标志（如 response.completed）
 			// 这样当上游完整返回但客户端取消时，可以正确识别为"流完整"而非 499
@@ -78,14 +198,24 @@ func streamCopyWithBufferSize(ctx context.Context, src io.Reader, dst http.Respo
 					if errors.Is(hookErr, errAbortStreamBeforeWrite) {
 						return hookErr
 					}
+					if errors.Is(hookErr, errStopStreamAfterWrite) {
+						stopAfterWrite = true
+						var stopErr *stopStreamAfterWriteError
+						if errors.As(hookErr, &stopErr) && stopErr.writeBytes >= 0 && stopErr.writeBytes <= n {
+							writeBytes = stopErr.writeBytes
+						}
+					}
 					_ = hookErr // 钩子错误不中断流传输（容错设计）
 				}
 			}
-			if _, writeErr := dst.Write(buf[:n]); writeErr != nil {
+			if _, writeErr := dst.Write(buf[:writeBytes]); writeErr != nil {
 				return writeErr
 			}
 			if flusher, ok := dst.(http.Flusher); ok {
 				flusher.Flush()
+			}
+			if stopAfterWrite {
+				return nil
 			}
 		}
 		if err != nil {

--- a/internal/app/proxy_stream_test.go
+++ b/internal/app/proxy_stream_test.go
@@ -2,8 +2,12 @@ package app
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"errors"
+	"io"
+	"net/http"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -23,6 +27,46 @@ type blockingReadCloser struct {
 	readOnce  sync.Once
 	entered   chan struct{}
 	closed    chan struct{}
+}
+
+type dataThenBlockReadCloser struct {
+	closeOnce sync.Once
+	data      []byte
+	offset    int
+	maxChunk  int
+	closed    chan struct{}
+}
+
+func newDataThenBlockReadCloser(data []byte, maxChunk int) *dataThenBlockReadCloser {
+	return &dataThenBlockReadCloser{
+		data:     data,
+		maxChunk: maxChunk,
+		closed:   make(chan struct{}),
+	}
+}
+
+func (r *dataThenBlockReadCloser) Read(p []byte) (int, error) {
+	if r.offset < len(r.data) {
+		n := len(r.data) - r.offset
+		if r.maxChunk > 0 && n > r.maxChunk {
+			n = r.maxChunk
+		}
+		if n > len(p) {
+			n = len(p)
+		}
+		copy(p, r.data[r.offset:r.offset+n])
+		r.offset += n
+		return n, nil
+	}
+	<-r.closed
+	return 0, errors.New("read closed")
+}
+
+func (r *dataThenBlockReadCloser) Close() error {
+	r.closeOnce.Do(func() {
+		close(r.closed)
+	})
+	return nil
 }
 
 func newBlockingReadCloser() *blockingReadCloser {
@@ -187,5 +231,331 @@ func TestStreamCopy_ClosesWrappedUnderlyingCloserOnContextCancel(t *testing.T) {
 	case <-time.After(200 * time.Millisecond):
 		_ = underlying.Close()
 		t.Fatal("streamCopy did not close wrapped underlying reader after context cancellation")
+	}
+}
+
+func TestStreamAndParseResponse_CodexCompletesWithoutEOF(t *testing.T) {
+	sse := []byte("event: response.created\ndata: {\"type\":\"response.created\"}\n\n" +
+		"event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":3,\"output_tokens\":4}}}\n\n")
+	reader := newDataThenBlockReadCloser(sse, 7)
+	defer func() { _ = reader.Close() }()
+	recorder := newRecorder()
+
+	type result struct {
+		parser usageParser
+		err    error
+	}
+	done := make(chan result, 1)
+	go func() {
+		parser, err := streamAndParseResponse(
+			context.Background(),
+			reader,
+			recorder,
+			"text/event-stream",
+			"codex",
+			true,
+			nil,
+		)
+		done <- result{parser: parser, err: err}
+	}()
+
+	select {
+	case got := <-done:
+		if got.err != nil {
+			t.Fatalf("streamAndParseResponse err=%v, want nil", got.err)
+		}
+		if got.parser == nil || !got.parser.IsStreamComplete() {
+			t.Fatal("streamAndParseResponse should preserve response.completed semantics")
+		}
+		if recorder.Body.String() != string(sse) {
+			t.Fatalf("forwarded body mismatch:\n got: %q\nwant: %q", recorder.Body.String(), string(sse))
+		}
+		if !recorder.Flushed {
+			t.Fatal("response.completed must be flushed before the stream returns")
+		}
+		input, output, _, _ := got.parser.GetUsage()
+		if input != 3 || output != 4 {
+			t.Fatalf("usage=(%d,%d), want (3,4)", input, output)
+		}
+	case <-time.After(200 * time.Millisecond):
+		_ = reader.Close()
+		<-done
+		t.Fatal("streamAndParseResponse kept waiting for EOF after response.completed")
+	}
+}
+
+func TestStreamAndParseResponse_CodexPreservesPartialEventAtEOF(t *testing.T) {
+	sse := "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"tail\"}"
+	recorder := newRecorder()
+
+	_, err := streamAndParseResponse(
+		context.Background(),
+		io.NopCloser(strings.NewReader(sse)),
+		recorder,
+		"text/event-stream",
+		"codex",
+		true,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("streamAndParseResponse err=%v, want nil", err)
+	}
+	if recorder.Body.String() != sse {
+		t.Fatalf("forwarded body mismatch:\n got: %q\nwant: %q", recorder.Body.String(), sse)
+	}
+}
+
+func TestStreamAndParseResponse_CodexBareCRCompletesWithoutEOF(t *testing.T) {
+	sse := []byte("event: response.completed\rdata: {\"type\":\"response.completed\"}\r\r")
+	reader := newDataThenBlockReadCloser(sse, 5)
+	defer func() { _ = reader.Close() }()
+
+	type result struct {
+		parser usageParser
+		err    error
+	}
+	done := make(chan result, 1)
+	recorder := newRecorder()
+	go func() {
+		parser, err := streamAndParseResponse(
+			context.Background(), reader, recorder, "text/event-stream", "codex", true, nil,
+		)
+		done <- result{parser: parser, err: err}
+	}()
+
+	select {
+	case got := <-done:
+		if got.err != nil {
+			t.Fatalf("streamAndParseResponse err=%v, want nil", got.err)
+		}
+		if got.parser == nil || !got.parser.IsStreamComplete() {
+			t.Fatal("bare-CR response.completed must preserve stream-complete semantics")
+		}
+		if recorder.Body.String() != string(sse) {
+			t.Fatalf("forwarded body mismatch:\n got: %q\nwant: %q", recorder.Body.String(), string(sse))
+		}
+	case <-time.After(200 * time.Millisecond):
+		_ = reader.Close()
+		<-done
+		t.Fatal("streamAndParseResponse kept waiting for EOF after bare-CR response.completed")
+	}
+}
+
+func TestStreamAndParseResponse_CodexBareCRCommitsDeferredWriter(t *testing.T) {
+	sse := []byte("event: response.completed\rdata: {\"type\":\"response.completed\"}\r\r")
+	target := newRecorder()
+	deferred := newDeferredResponseWriter(target)
+
+	parser, err := streamAndParseResponse(
+		context.Background(),
+		io.NopCloser(bytes.NewReader(sse)),
+		deferred,
+		"text/event-stream",
+		"codex",
+		true,
+		func(parser usageParser) error {
+			if parser.HasStreamOutput() || parser.IsStreamComplete() {
+				return deferred.Commit()
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("streamAndParseResponse err=%v, want nil", err)
+	}
+	if parser == nil || !parser.IsStreamComplete() {
+		t.Fatal("bare-CR response.completed must preserve stream-complete semantics")
+	}
+	if !deferred.Committed() {
+		t.Fatal("bare-CR response.completed must commit the production deferred writer")
+	}
+	if target.Body.String() != string(sse) {
+		t.Fatalf("forwarded body mismatch:\n got: %q\nwant: %q", target.Body.String(), string(sse))
+	}
+}
+
+func TestHandleSuccessResponse_CodexBareCRCommitsProductionDeferredWriter(t *testing.T) {
+	sse := []byte("event: response.completed\rdata: {\"type\":\"response.completed\"}\r\r")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	reqCtx := &requestContext{
+		ctx:         ctx,
+		cancel:      cancel,
+		startTime:   time.Now(),
+		isStreaming: true,
+	}
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(bytes.NewReader(sse)),
+	}
+	recorder := newRecorder()
+
+	_, _, err := (&Server{}).handleSuccessResponse(
+		reqCtx,
+		resp,
+		resp.Header.Clone(),
+		recorder,
+		"codex",
+		&streamReadStats{totalBytes: int64(len(sse))},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("handleSuccessResponse err=%v, want nil", err)
+	}
+	if recorder.Body.String() != string(sse) {
+		t.Fatalf("forwarded body mismatch:\n got: %q\nwant: %q", recorder.Body.String(), string(sse))
+	}
+}
+
+func TestStreamAndParseResponse_CodexStopsAtTerminalBoundary(t *testing.T) {
+	terminal := []byte("event: response.completed\ndata: {\"type\":\"response.completed\"}\n\n")
+	trailing := []byte("event: response.output_text.delta\ndata: {\"delta\":\"late\"}\n\n")
+	reader := newDataThenBlockReadCloser(append(append([]byte(nil), terminal...), trailing...), len(terminal)+len(trailing))
+	defer func() { _ = reader.Close() }()
+	recorder := newRecorder()
+
+	_, err := streamAndParseResponse(
+		context.Background(), reader, recorder, "text/event-stream", "codex", true, nil,
+	)
+	if err != nil {
+		t.Fatalf("streamAndParseResponse err=%v, want nil", err)
+	}
+	if recorder.Body.String() != string(terminal) {
+		t.Fatalf("forwarded body mismatch:\n got: %q\nwant: %q", recorder.Body.String(), string(terminal))
+	}
+}
+
+func TestStreamAndParseResponse_CodexShortTextPlainCompletesWithoutEOF(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		sse  []byte
+	}{
+		{name: "LF", sse: []byte("event: response.completed\ndata: {\"type\":\"response.completed\"}\n\n")},
+		{name: "bare CR", sse: []byte("event: response.completed\rdata: {\"type\":\"response.completed\"}\r\r")},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := newDataThenBlockReadCloser(tt.sse, 7)
+			defer func() { _ = reader.Close() }()
+			recorder := newRecorder()
+
+			type result struct {
+				parser usageParser
+				err    error
+			}
+			done := make(chan result, 1)
+			go func() {
+				parser, err := streamAndParseResponse(
+					context.Background(), reader, recorder, "text/plain", "codex", true, nil,
+				)
+				done <- result{parser: parser, err: err}
+			}()
+
+			select {
+			case got := <-done:
+				if got.err != nil {
+					t.Fatalf("streamAndParseResponse err=%v, want nil", got.err)
+				}
+				if got.parser == nil || !got.parser.IsStreamComplete() {
+					t.Fatal("short text/plain response.completed must preserve stream-complete semantics")
+				}
+				if recorder.Body.String() != string(tt.sse) {
+					t.Fatalf("forwarded body mismatch:\n got: %q\nwant: %q", recorder.Body.String(), string(tt.sse))
+				}
+			case <-time.After(200 * time.Millisecond):
+				_ = reader.Close()
+				<-done
+				t.Fatal("text/plain SSE probing waited for 2048 bytes or EOF")
+			}
+		})
+	}
+}
+
+func TestStreamAndParseResponse_CodexPreservesSplitTerminalCRLF(t *testing.T) {
+	sse := []byte("event: response.completed\r\ndata: {\"type\":\"response.completed\"}\r\n\r\n")
+	reader := newDataThenBlockReadCloser(sse, 1)
+	defer func() { _ = reader.Close() }()
+	recorder := newRecorder()
+
+	_, err := streamAndParseResponse(
+		context.Background(), reader, recorder, "text/event-stream", "codex", true, nil,
+	)
+	if err != nil {
+		t.Fatalf("streamAndParseResponse err=%v, want nil", err)
+	}
+	if recorder.Body.String() != string(sse) {
+		t.Fatalf("forwarded body mismatch:\n got: %q\nwant: %q", recorder.Body.String(), string(sse))
+	}
+}
+
+func TestResponsesCompletedDetector_LineEndings(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		separator string
+	}{
+		{name: "LF", separator: "\n"},
+		{name: "CRLF", separator: "\r\n"},
+		{name: "CR", separator: "\r"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			detector := newResponsesCompletedDetector()
+			event := []byte("event: response.completed" + tt.separator + "data: {}" + tt.separator)
+			for _, b := range event {
+				if detector.Feed([]byte{b}) {
+					t.Fatal("detector completed before the blank event delimiter")
+				}
+			}
+			if !detector.Feed([]byte(tt.separator)) {
+				t.Fatalf("detector did not recognize response.completed with separator %q", tt.separator)
+			}
+		})
+	}
+}
+
+func TestResponsesCompletedDetector_UsesMostRecentLineEndingStyle(t *testing.T) {
+	detector := newResponsesCompletedDetector()
+	if detector.Feed([]byte("event: response.completed\r\ndata: {}\n")) {
+		t.Fatal("detector completed before the blank event delimiter")
+	}
+	if !detector.Feed([]byte{'\r'}) {
+		t.Fatal("bare-CR terminal delimiter after an LF line must complete immediately")
+	}
+}
+
+func TestResponsesCompletedDetector_DoesNotBufferUnboundedLines(t *testing.T) {
+	detector := newResponsesCompletedDetector()
+	if detector.Feed(bytes.Repeat([]byte{'x'}, 1<<20)) {
+		t.Fatal("unterminated non-event line must not complete the stream")
+	}
+	if len(detector.line) > maxTrackedSSELineBytes {
+		t.Fatalf("tracked line grew to %d bytes, limit=%d", len(detector.line), maxTrackedSSELineBytes)
+	}
+}
+
+func TestResponsesCompletedDetector_RequiresExactEventType(t *testing.T) {
+	for _, eventLine := range []string{
+		"event: response.output_item.done",
+		"event: response.failed",
+		"event: response.completed.extra",
+		"event:	response.completed",
+		"event:  response.completed",
+		"event: response.completed ",
+	} {
+		detector := newResponsesCompletedDetector()
+		if detector.Feed([]byte(eventLine + "\n\n")) {
+			t.Fatalf("event line %q must not complete the stream", eventLine)
+		}
+	}
+}
+
+func TestResponsesCompletedDetector_AllowsOversizedDataAfterTerminalEvent(t *testing.T) {
+	detector := newResponsesCompletedDetector()
+	payload := append([]byte("event: response.completed\ndata: "), bytes.Repeat([]byte{'x'}, 1<<20)...)
+	payload = append(payload, '\n', '\n')
+	if !detector.Feed(payload) {
+		t.Fatal("oversized data line must not hide a preceding response.completed event type")
+	}
+	if len(detector.line) > maxTrackedSSELineBytes {
+		t.Fatalf("tracked line grew to %d bytes, limit=%d", len(detector.line), maxTrackedSSELineBytes)
 	}
 }


### PR DESCRIPTION
## Summary

- stop native Codex/Responses SSE forwarding after a complete `response.completed` event has been written and flushed downstream
- preserve fixed-size chunk forwarding for every protocol; native Codex only adds a bounded terminal-event detector
- support LF, CRLF (including delimiters split across reads), and bare-CR SSE framing without buffering full events
- stop exactly at the terminal event boundary instead of forwarding trailing bytes from the same read
- classify short `text/plain` SSE streams incrementally instead of waiting for 2 KiB or EOF
- add a regression test for a fragmented upstream SSE response that emits `response.completed` and then never returns EOF
- preserve terminal usage parsing and the full downstream completion event

This is protocol-generic rather than AnyRouter-specific. The production incident that exposed it was an intermittent AnyRouter stream observed on 2026-07-14, documented in #80.

## Why

Some Responses-compatible upstreams can emit a valid terminal SSE event but leave the HTTP response body open. ccLoad already recognizes `response.completed` semantically, but previously continued reading until EOF or context cancellation. That can keep downstream gateways waiting until their stream-idle timeout fires.

The new path preserves fixed-size chunk forwarding and keeps at most 256 bytes of SSE line state to recognize the exact terminal event across LF, CRLF, or bare-CR framing. The chunk containing the completed event is written and flushed before the reader returns. It does not synthesize a completion event and does not terminate on intermediate events such as `response.output_item.done`.

## Test plan

- `go test -tags sonic ./internal/...`
- `go vet -tags sonic ./internal/...`
- `make race-fast`
- `make build`

Fixes #80
