### PR TITLE
feat(selector): optional channel TTFB relative priority penalty

### DIFF
--- a/docs/superpowers/plans/2026-07-15-channel-ttfb-priority.md
+++ b/docs/superpowers/plans/2026-07-15-channel-ttfb-priority.md
@@ -1,0 +1,21 @@
+# Channel TTFB Priority Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add optional channel-level first-byte (TTFB) penalty into effective priority scoring using relative median slowness among same-request candidates.
+
+**Architecture:** Extend `ChannelHealthStats` + success-rate query with TTFB aggregates; load new settings into `HealthScoreConfig`; compute median L_med over current candidates in `sortChannelsByHealth`; subtract TTFB penalty in `calculateEffectivePriority`. Defaults off.
+
+**Tech Stack:** Go, existing health cache / selector balancer, SQLite/MySQL logs aggregate SQL, system_settings seed.
+
+**Spec:** `docs/superpowers/specs/2026-07-15-channel-ttfb-priority-design.md`
+
+## Tasks overview
+
+1. Model + settings defaults
+2. SQL aggregate TTFB into GetChannelSuccessRates
+3. Formula + median in selector_balancer
+4. loadHealthScoreConfig + health cache default zero values
+5. Unit/integration tests
+6. Verify
+

--- a/docs/superpowers/specs/2026-07-15-channel-ttfb-priority-design.md
+++ b/docs/superpowers/specs/2026-07-15-channel-ttfb-priority-design.md
@@ -1,0 +1,232 @@
+# Channel TTFB Priority Scoring — Design Spec
+
+**Date:** 2026-07-15  
+**Status:** Approved for planning  
+**Workspace:** `/root/docker/ccLoad-src`
+
+---
+
+## 1. Goal
+
+Extend channel selection so **effective priority** can penalize channels that are slower than peers on first-byte time (TTFB), while keeping:
+
+- manual `Priority` as the primary control
+- existing success-rate health penalty
+- same-priority Key-count smooth weighted RR
+- multi-URL `1/TTFB_EWMA` selection unchanged
+
+---
+
+## 2. Locked decisions
+
+| Topic | Choice |
+|-------|--------|
+| Scope | Channel-level effective priority only |
+| URL-level | Unchanged (`URLSelector`: explore-first, weight `1/latency`) |
+| TTFB form | Relative to **median** of same-request candidate channels |
+| Reward fast channels? | **No** (v1 only penalizes slower-than-median) |
+| Absolute ms thresholds | **No** (model/protocol baselines differ too much) |
+| Default | **Off** (`enable_ttfb_score=false`) |
+| Coupling | Works only when `enable_health_score=true` (shares health window/cache path) |
+| Failures in TTFB avg | **Exclude** failed/timeout requests; success-rate penalty already covers reliability |
+
+---
+
+## 3. Formula (plain text)
+
+```text
+P_eff = P_base - Penalty_fail - Penalty_ttfb
+```
+
+### Failure penalty (existing)
+
+```text
+Penalty_fail = (1 - success_rate) * W_fail * conf_fail
+conf_fail    = min(1, request_samples / min_confident_sample)
+W_fail default = 100
+min_confident_sample default = 20
+```
+
+### TTFB penalty (new)
+
+```text
+s = L_ch / L_med
+
+Penalty_ttfb = clamp(s - 1, 0, S_max) * W_ttfb * conf_ttfb
+
+conf_ttfb = min(1, ttfb_samples / ttfb_min_confident_sample)
+```
+
+Definitions:
+
+| Symbol | Meaning |
+|--------|---------|
+| `P_base` | Channel `Priority` |
+| `L_ch` | Channel avg first-byte seconds in window (successful proxy logs with `first_byte_time > 0`) |
+| `L_med` | Median of `L_ch` among **current route candidates** that have enough TTFB samples |
+| `s` | Relative slowness vs median |
+| `S_max` | Cap on `(s-1)`, default `2.0` (treat at most 3x slower) |
+| `W_ttfb` | `ttfb_penalty_weight`, default `20` |
+| `ttfb_min_confident_sample` | default `10` |
+
+`clamp(x, 0, S_max)`:
+
+- if channel is as fast or faster than median → penalty `0`
+- if slower → proportional penalty up to `S_max * W_ttfb` at full confidence
+
+### When Penalty_ttfb is forced to 0
+
+1. `enable_ttfb_score=false`
+2. `enable_health_score=false`
+3. Fewer than **2** candidate channels have valid `L_ch` with `ttfb_samples > 0`
+4. This channel has `ttfb_samples == 0`
+5. `L_med <= 0` (defensive)
+
+---
+
+## 4. Worked defaults
+
+```text
+P_eff =
+  Priority
+  - (1 - success_rate) * 100 * min(1, N_req / 20)
+  - min(max(L_ch / L_med - 1, 0), 2) * 20 * min(1, N_ttfb / 10)
+```
+
+Examples at `Priority=100`, full confidence, perfect success rate:
+
+| Relative TTFB | Penalty_ttfb | P_eff |
+|---------------|--------------|-------|
+| = median | 0 | 100 |
+| 1.5x median | 10 | 90 |
+| 2x median | 20 | 80 |
+| >= 3x median | 40 | 60 |
+
+---
+
+## 5. Selection pipeline (after change)
+
+```text
+1. Filter available channels (model, protocol, cooldown, token ACL, cost, RPM, concurrency)
+2. If health score disabled:
+     sort by Priority, same-priority Key RR   # unchanged
+3. If health score enabled:
+     for each channel compute P_eff (fail ± ttfb)
+     sort by P_eff desc
+     bucket by effPriorityBucket (0.1)
+     same-bucket Key RR
+4. For chosen channel multi-URL: existing URLSelector
+```
+
+`L_med` is computed on the **filtered candidate list for this request** (same model/protocol pool), not global all-channels, so Claude vs Gemini baselines do not mix.
+
+---
+
+## 6. Data model
+
+### Extend `ChannelHealthStats`
+
+```go
+type ChannelHealthStats struct {
+	SuccessRate         float64
+	SampleCount         int64
+	AvgFirstByteSeconds float64 // 0 if none
+	FirstByteSampleCount int64
+}
+```
+
+### Aggregation source
+
+Reuse health window (`health_score_window_minutes`):
+
+- success rate: existing `GetChannelSuccessRates` semantics
+- TTFB: average of `logs.first_byte_time` where:
+  - `log_source = proxy`
+  - `status_code` in 2xx
+  - `first_byte_time > 0`
+  - within window
+  - group by `channel_id`
+
+Prefer extending the same SQL used by success rates to also return TTFB aggregates (one query / one cache refresh).
+
+### Cache
+
+`HealthCache` already snapshots success rates on an interval. Extend snapshot to include TTFB fields. No per-request DB query.
+
+---
+
+## 7. Config / settings
+
+| Key | Type | Default | Notes |
+|-----|------|---------|-------|
+| `enable_ttfb_score` | bool | `false` | Requires health score path |
+| `ttfb_penalty_weight` | int | `20` | `W_ttfb` |
+| `ttfb_max_slow_ratio` | float/string | `2.0` | `S_max` on `(s-1)` |
+| `ttfb_min_confident_sample` | int | `10` | Full penalty sample threshold |
+
+Window/update interval reuse:
+
+- `health_score_window_minutes`
+- `health_score_update_interval`
+
+Validation:
+
+- weights >= 0
+- samples >= 1
+- max_slow_ratio >= 0 (0 disables ttfb penalty magnitude even if enabled)
+
+Admin settings API / UI: add toggles next to existing health-score settings if those exist; otherwise settings keys only in v1 is acceptable if UI already generic for system settings.
+
+---
+
+## 8. Code map
+
+| Area | Change |
+|------|--------|
+| `internal/model/health.go` | stats + config fields, defaults |
+| `internal/storage/...` success-rate query | add TTFB avg/count |
+| `internal/app/health_cache.go` | carry new fields |
+| `internal/app/selector_balancer.go` | `calculateEffectivePriority` + median helper |
+| `internal/app/server.go` `loadHealthScoreConfig` | load new settings |
+| `internal/storage/migrate.go` / settings seed | register defaults |
+| tests | formula unit + selection integration |
+
+---
+
+## 9. Non-goals (v1)
+
+- Rewarding faster-than-median channels
+- Absolute TTFB thresholds (e.g. always penalize >800ms)
+- Using multi-URL EWMA as channel TTFB (logs first)
+- Replacing Key-count RR inside buckets with TTFB weights
+- Cross-model global median
+- Persisting P_eff to DB
+
+---
+
+## 10. Tests
+
+1. Unit: pure formula table (fast/median/slow/cap/low-sample/zero-med candidates)
+2. Unit: median of odd/even candidate sets
+3. Unit: ttfb disabled → identical to fail-only priority
+4. Unit: health disabled → no ttfb path
+5. Integration: two channels same Priority; slower TTFB gets lower P_eff and is tried later when health+ttfb on
+6. Storage: success-rate query returns first-byte aggregates for successful logs only
+
+---
+
+## 11. Rollout
+
+1. Ship code with defaults off
+2. Enable `enable_health_score` if not already
+3. Enable `enable_ttfb_score` on staging / one model pool
+4. Watch channel order vs dashboard avg first-byte
+5. Tune `ttfb_penalty_weight` (start 20; raise only if slow channels still steal traffic)
+
+---
+
+## 12. Spec self-review
+
+- No TBD for v1 formula/params
+- Compatible with existing Priority and fail penalty
+- Scope limited to channel effective priority + stats aggregation

--- a/internal/app/admin_channels.go
+++ b/internal/app/admin_channels.go
@@ -229,9 +229,19 @@ func (s *Server) sortChannelsByEffectivePriority(cfgs []*model.Config, healthEna
 	successRateMap = make(map[int64]float64, len(cfgs))
 	if healthEnabled {
 		hcfg := s.healthCache.Config()
+		samples := make([]float64, 0, len(cfgs))
+		statsByID := make(map[int64]model.ChannelHealthStats, len(cfgs))
 		for _, cfg := range cfgs {
 			stats := s.healthCache.GetHealthStats(cfg.ID)
-			priorityMap[cfg.ID] = s.calculateEffectivePriority(cfg, stats, hcfg)
+			statsByID[cfg.ID] = stats
+			if stats.FirstByteSampleCount > 0 && stats.AvgFirstByteSeconds > 0 {
+				samples = append(samples, stats.AvgFirstByteSeconds)
+			}
+		}
+		medianTTFB := medianFloat64(samples)
+		for _, cfg := range cfgs {
+			stats := statsByID[cfg.ID]
+			priorityMap[cfg.ID] = s.calculateEffectivePriority(cfg, stats, hcfg, medianTTFB)
 			if stats.SampleCount > 0 {
 				successRateMap[cfg.ID] = stats.SuccessRate
 			}

--- a/internal/app/selector_balancer.go
+++ b/internal/app/selector_balancer.go
@@ -45,12 +45,24 @@ func (s *Server) sortChannelsByHealth(
 
 	cfg := s.healthCache.Config()
 
+	// Preload stats and compute candidate median TTFB for relative penalty.
+	statsByID := make(map[int64]modelpkg.ChannelHealthStats, len(channels))
+	ttfbSamples := make([]float64, 0, len(channels))
+	for _, ch := range channels {
+		st := s.healthCache.GetHealthStats(ch.ID)
+		statsByID[ch.ID] = st
+		if st.FirstByteSampleCount > 0 && st.AvgFirstByteSeconds > 0 {
+			ttfbSamples = append(ttfbSamples, st.AvgFirstByteSeconds)
+		}
+	}
+	medianTTFB := medianFloat64(ttfbSamples)
+
 	scored := make([]channelWithScore, len(channels))
 	for i, ch := range channels {
-		stats := s.healthCache.GetHealthStats(ch.ID)
+		stats := statsByID[ch.ID]
 		scored[i] = channelWithScore{
 			config:      ch,
-			effPriority: s.calculateEffectivePriority(ch, stats, cfg),
+			effPriority: s.calculateEffectivePriority(ch, stats, cfg, medianTTFB),
 		}
 	}
 
@@ -80,12 +92,13 @@ func (s *Server) sortChannelsByHealth(
 }
 
 // calculateEffectivePriority 计算渠道的有效优先级
-// 有效优先级 = 基础优先级 - 成功率惩罚 × 置信度（越大越优先）
-// 置信度 = min(1.0, 样本量 / 置信阈值)，样本量越小惩罚越轻
+// P_eff = Priority - Penalty_fail - Penalty_ttfb
+// 越大越优先。medianTTFB 为当前候选集有效首字中位数（秒），<=0 表示不启用相对首字惩罚。
 func (s *Server) calculateEffectivePriority(
 	ch *modelpkg.Config,
 	stats modelpkg.ChannelHealthStats,
 	cfg modelpkg.HealthScoreConfig,
+	medianTTFB float64,
 ) float64 {
 	basePriority := float64(ch.Priority)
 
@@ -97,16 +110,56 @@ func (s *Server) calculateEffectivePriority(
 	}
 	failureRate := 1.0 - successRate
 
-	// 置信度：样本量越小，惩罚打折越多
-	confidence := 1.0
+	// 失败惩罚置信度：样本量越小，惩罚打折越多
+	failConfidence := 1.0
 	if cfg.MinConfidentSample > 0 {
-		confidence = min(1.0, float64(stats.SampleCount)/float64(cfg.MinConfidentSample))
+		failConfidence = min(1.0, float64(stats.SampleCount)/float64(cfg.MinConfidentSample))
+	}
+	penaltyFail := failureRate * float64(cfg.SuccessRatePenaltyWeight) * failConfidence
+
+	penaltyTTFB := 0.0
+	if cfg.EnableTTFBScore && medianTTFB > 0 && stats.FirstByteSampleCount > 0 && stats.AvgFirstByteSeconds > 0 && cfg.TTFBPenaltyWeight > 0 {
+		sRatio := stats.AvgFirstByteSeconds / medianTTFB
+		slow := sRatio - 1.0
+		if slow < 0 {
+			slow = 0
+		}
+		maxSlow := cfg.TTFBMaxSlowRatio
+		if maxSlow < 0 {
+			maxSlow = 0
+		}
+		if slow > maxSlow {
+			slow = maxSlow
+		}
+		ttfbConfidence := 1.0
+		if cfg.TTFBMinConfidentSample > 0 {
+			ttfbConfidence = min(1.0, float64(stats.FirstByteSampleCount)/float64(cfg.TTFBMinConfidentSample))
+		}
+		penaltyTTFB = slow * cfg.TTFBPenaltyWeight * ttfbConfidence
 	}
 
-	// 惩罚 = 失败率 × 权重 × 置信度
-	penalty := failureRate * float64(cfg.SuccessRatePenaltyWeight) * confidence
+	return basePriority - penaltyFail - penaltyTTFB
+}
 
-	return basePriority - penalty
+// medianFloat64 returns the median of values. Empty input returns 0.
+// Requires at least 2 values for relative scoring callers; this helper itself
+// still returns a median for a single value.
+func medianFloat64(values []float64) float64 {
+	n := len(values)
+	if n == 0 {
+		return 0
+	}
+	// Need >=2 peers for relative median comparison in caller.
+	if n < 2 {
+		return 0
+	}
+	cp := append([]float64(nil), values...)
+	sort.Float64s(cp)
+	mid := n / 2
+	if n%2 == 1 {
+		return cp[mid]
+	}
+	return (cp[mid-1] + cp[mid]) / 2
 }
 
 // balanceSamePriorityChannels 按优先级分组，组内使用平滑加权轮询

--- a/internal/app/selector_balancer_test.go
+++ b/internal/app/selector_balancer_test.go
@@ -3,6 +3,8 @@ package app
 import (
 	"math"
 	"testing"
+
+	modelpkg "ccLoad/internal/model"
 )
 
 func TestEffPriorityBucket_FloatEdge(t *testing.T) {
@@ -17,5 +19,102 @@ func TestEffPriorityBucket_FloatEdge(t *testing.T) {
 	pNeg := scaledNeg / 10
 	if got := effPriorityBucket(pNeg); got != -51 {
 		t.Fatalf("expected bucket=-51, got %d (p=%v scaled=%v)", got, pNeg, pNeg*10)
+	}
+}
+
+func TestMedianFloat64(t *testing.T) {
+	t.Parallel()
+	if got := medianFloat64(nil); got != 0 {
+		t.Fatalf("empty=%v", got)
+	}
+	if got := medianFloat64([]float64{1.0}); got != 0 {
+		// fewer than 2 peers → 0 for relative scoring
+		t.Fatalf("single=%v want 0", got)
+	}
+	if got := medianFloat64([]float64{1.0, 3.0}); got != 2.0 {
+		t.Fatalf("even=%v want 2", got)
+	}
+	if got := medianFloat64([]float64{1.0, 2.0, 100.0}); got != 2.0 {
+		t.Fatalf("odd=%v want 2", got)
+	}
+}
+
+func TestCalculateEffectivePriority_TTFBPenalty(t *testing.T) {
+	t.Parallel()
+	s := &Server{}
+	cfg := modelpkg.HealthScoreConfig{
+		Enabled:                  true,
+		SuccessRatePenaltyWeight: 100,
+		MinConfidentSample:       20,
+		EnableTTFBScore:          true,
+		TTFBPenaltyWeight:        20,
+		TTFBMaxSlowRatio:         2.0,
+		TTFBMinConfidentSample:   10,
+	}
+	ch := &modelpkg.Config{ID: 1, Priority: 100}
+
+	// Perfect success, same as median → no ttfb penalty
+	stats := modelpkg.ChannelHealthStats{
+		SuccessRate: 1, SampleCount: 100,
+		AvgFirstByteSeconds: 1.0, FirstByteSampleCount: 20,
+	}
+	got := s.calculateEffectivePriority(ch, stats, cfg, 1.0)
+	if got != 100 {
+		t.Fatalf("equal median: got %v want 100", got)
+	}
+
+	// 2x median, full confidence → penalty 20
+	stats.AvgFirstByteSeconds = 2.0
+	got = s.calculateEffectivePriority(ch, stats, cfg, 1.0)
+	if got != 80 {
+		t.Fatalf("2x median: got %v want 80", got)
+	}
+
+	// 4x median capped at (s-1)=2 → penalty 40
+	stats.AvgFirstByteSeconds = 4.0
+	got = s.calculateEffectivePriority(ch, stats, cfg, 1.0)
+	if got != 60 {
+		t.Fatalf("4x median capped: got %v want 60", got)
+	}
+
+	// Faster than median → no reward
+	stats.AvgFirstByteSeconds = 0.5
+	got = s.calculateEffectivePriority(ch, stats, cfg, 1.0)
+	if got != 100 {
+		t.Fatalf("faster: got %v want 100", got)
+	}
+
+	// Low sample halves confidence (5/10)
+	stats.AvgFirstByteSeconds = 2.0
+	stats.FirstByteSampleCount = 5
+	got = s.calculateEffectivePriority(ch, stats, cfg, 1.0)
+	if got != 90 {
+		t.Fatalf("half confidence: got %v want 90", got)
+	}
+
+	// Disabled ttfb
+	cfg.EnableTTFBScore = false
+	stats.FirstByteSampleCount = 20
+	got = s.calculateEffectivePriority(ch, stats, cfg, 1.0)
+	if got != 100 {
+		t.Fatalf("disabled: got %v want 100", got)
+	}
+
+	// Fail penalty still applies with ttfb
+	cfg.EnableTTFBScore = true
+	stats.SuccessRate = 0.8
+	stats.SampleCount = 20
+	stats.AvgFirstByteSeconds = 2.0
+	// fail: 0.2*100*1=20, ttfb:20 → 100-20-20=60
+	got = s.calculateEffectivePriority(ch, stats, cfg, 1.0)
+	if got != 60 {
+		t.Fatalf("fail+ttfb: got %v want 60", got)
+	}
+
+	// medianTTFB=0 disables relative penalty
+	stats.SuccessRate = 1
+	got = s.calculateEffectivePriority(ch, stats, cfg, 0)
+	if got != 100 {
+		t.Fatalf("no median: got %v want 100", got)
 	}
 }

--- a/internal/app/selector_cooldown.go
+++ b/internal/app/selector_cooldown.go
@@ -153,18 +153,29 @@ func (s *Server) pickBestChannelWhenAllCooled(
 		return readyAt
 	}
 
-	// 计算有效优先级
-	getEffPriority := func(ch *modelpkg.Config) float64 {
-		if healthEnabled {
-			return s.calculateEffectivePriority(ch, s.healthCache.GetHealthStats(ch.ID), healthCfg)
-		}
-		return float64(ch.Priority)
-	}
-
 	// 过滤nil并找最优
 	valid := slices.DeleteFunc(slices.Clone(channels), func(ch *modelpkg.Config) bool { return ch == nil })
 	if len(valid) == 0 {
 		return nil, 0
+	}
+
+	// 计算有效优先级（含候选集首字中位）
+	medianTTFB := 0.0
+	if healthEnabled {
+		samples := make([]float64, 0, len(valid))
+		for _, ch := range valid {
+			st := s.healthCache.GetHealthStats(ch.ID)
+			if st.FirstByteSampleCount > 0 && st.AvgFirstByteSeconds > 0 {
+				samples = append(samples, st.AvgFirstByteSeconds)
+			}
+		}
+		medianTTFB = medianFloat64(samples)
+	}
+	getEffPriority := func(ch *modelpkg.Config) float64 {
+		if healthEnabled {
+			return s.calculateEffectivePriority(ch, s.healthCache.GetHealthStats(ch.ID), healthCfg, medianTTFB)
+		}
+		return float64(ch.Priority)
 	}
 
 	best := slices.MinFunc(valid, func(a, b *modelpkg.Config) int {

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -409,12 +409,31 @@ func loadHealthScoreConfig(cs *ConfigService) model.HealthScoreConfig {
 		log.Printf("[WARN] 无效的 health_min_confident_sample=%d（必须 >= 1），已使用默认值 %d", minConfidentSample, defaultHealthCfg.MinConfidentSample)
 		minConfidentSample = defaultHealthCfg.MinConfidentSample
 	}
+	ttfbPenaltyWeight := cs.GetFloat("ttfb_penalty_weight", defaultHealthCfg.TTFBPenaltyWeight)
+	if ttfbPenaltyWeight < 0 {
+		log.Printf("[WARN] 无效的 ttfb_penalty_weight=%v（必须 >= 0），已使用默认值 %v", ttfbPenaltyWeight, defaultHealthCfg.TTFBPenaltyWeight)
+		ttfbPenaltyWeight = defaultHealthCfg.TTFBPenaltyWeight
+	}
+	ttfbMaxSlowRatio := cs.GetFloat("ttfb_max_slow_ratio", defaultHealthCfg.TTFBMaxSlowRatio)
+	if ttfbMaxSlowRatio < 0 {
+		log.Printf("[WARN] 无效的 ttfb_max_slow_ratio=%v（必须 >= 0），已使用默认值 %v", ttfbMaxSlowRatio, defaultHealthCfg.TTFBMaxSlowRatio)
+		ttfbMaxSlowRatio = defaultHealthCfg.TTFBMaxSlowRatio
+	}
+	ttfbMinConfidentSample := cs.GetInt("ttfb_min_confident_sample", defaultHealthCfg.TTFBMinConfidentSample)
+	if ttfbMinConfidentSample < 1 {
+		log.Printf("[WARN] 无效的 ttfb_min_confident_sample=%d（必须 >= 1），已使用默认值 %d", ttfbMinConfidentSample, defaultHealthCfg.TTFBMinConfidentSample)
+		ttfbMinConfidentSample = defaultHealthCfg.TTFBMinConfidentSample
+	}
 	return model.HealthScoreConfig{
 		Enabled:                  cs.GetBool("enable_health_score", defaultHealthCfg.Enabled),
 		SuccessRatePenaltyWeight: successRatePenaltyWeight,
 		WindowMinutes:            windowMinutes,
 		UpdateIntervalSeconds:    updateInterval,
 		MinConfidentSample:       minConfidentSample,
+		EnableTTFBScore:          cs.GetBool("enable_ttfb_score", defaultHealthCfg.EnableTTFBScore),
+		TTFBPenaltyWeight:        ttfbPenaltyWeight,
+		TTFBMaxSlowRatio:         ttfbMaxSlowRatio,
+		TTFBMinConfidentSample:   ttfbMinConfidentSample,
 	}
 }
 

--- a/internal/model/config_additional_test.go
+++ b/internal/model/config_additional_test.go
@@ -118,6 +118,12 @@ func TestDefaultHealthScoreConfig(t *testing.T) {
 	if cfg.SuccessRatePenaltyWeight <= 0 || cfg.WindowMinutes <= 0 || cfg.UpdateIntervalSeconds <= 0 || cfg.MinConfidentSample <= 0 {
 		t.Fatalf("unexpected default config: %+v", cfg)
 	}
+	if cfg.EnableTTFBScore {
+		t.Fatal("default ttfb score should be disabled")
+	}
+	if cfg.TTFBPenaltyWeight <= 0 || cfg.TTFBMaxSlowRatio <= 0 || cfg.TTFBMinConfidentSample <= 0 {
+		t.Fatalf("unexpected ttfb defaults: %+v", cfg)
+	}
 }
 
 func TestGetURLs_SingleURL(t *testing.T) {

--- a/internal/model/health.go
+++ b/internal/model/health.go
@@ -2,17 +2,23 @@ package model
 
 // ChannelHealthStats 渠道健康统计数据
 type ChannelHealthStats struct {
-	SuccessRate float64 // 成功率 0-1
-	SampleCount int64   // 样本量
+	SuccessRate          float64 // 成功率 0-1
+	SampleCount          int64   // 样本量（健康度口径请求数）
+	AvgFirstByteSeconds  float64 // 成功请求平均首字节时间（秒），无样本时为 0
+	FirstByteSampleCount int64   // 有效首字节样本数
 }
 
 // HealthScoreConfig 健康度排序配置
 type HealthScoreConfig struct {
-	Enabled                  bool // 是否启用健康度排序
-	SuccessRatePenaltyWeight int  // 成功率惩罚权重(乘以失败率)
-	WindowMinutes            int  // 成功率统计时间窗口(分钟)
-	UpdateIntervalSeconds    int  // 成功率缓存更新间隔(秒)
-	MinConfidentSample       int  // 置信样本量阈值（样本量达到此值时惩罚全额生效）
+	Enabled                  bool    // 是否启用健康度排序
+	SuccessRatePenaltyWeight int     // 成功率惩罚权重(乘以失败率)
+	WindowMinutes            int     // 成功率统计时间窗口(分钟)
+	UpdateIntervalSeconds    int     // 成功率缓存更新间隔(秒)
+	MinConfidentSample       int     // 置信样本量阈值（样本量达到此值时惩罚全额生效）
+	EnableTTFBScore          bool    // 是否启用首字相对惩罚
+	TTFBPenaltyWeight        float64 // 首字惩罚权重 W_ttfb
+	TTFBMaxSlowRatio         float64 // (s-1) 上限 S_max
+	TTFBMinConfidentSample   int     // 首字置信样本量阈值
 }
 
 // DefaultHealthScoreConfig 返回默认健康度配置
@@ -23,5 +29,9 @@ func DefaultHealthScoreConfig() HealthScoreConfig {
 		WindowMinutes:            5,
 		UpdateIntervalSeconds:    30,
 		MinConfidentSample:       20, // 默认20次请求才全额惩罚
+		EnableTTFBScore:          false,
+		TTFBPenaltyWeight:        20,
+		TTFBMaxSlowRatio:         2.0,
+		TTFBMinConfidentSample:   10,
 	}
 }

--- a/internal/storage/migrate.go
+++ b/internal/storage/migrate.go
@@ -353,6 +353,10 @@ func initDefaultSettings(ctx context.Context, db *sql.DB, dialect Dialect) error
 		{"health_score_window_minutes", "30", "int", "成功率统计时间窗口(分钟)", "30"},
 		{"health_score_update_interval", "30", "int", "成功率缓存更新间隔(秒)", "30"},
 		{"health_min_confident_sample", "20", "int", "置信样本量阈值(样本量达到此值时惩罚全额生效)", "20"},
+		{"enable_ttfb_score", "false", "bool", "启用渠道首字相对延迟惩罚(需同时开启enable_health_score)", "false"},
+		{"ttfb_penalty_weight", "20", "float", "首字惩罚权重(相对中位慢1倍时全置信惩罚值)", "20"},
+		{"ttfb_max_slow_ratio", "2", "float", "首字相对慢速比(s-1)上限", "2"},
+		{"ttfb_min_confident_sample", "10", "int", "首字置信样本量阈值", "10"},
 		// 冷却兜底配置
 		{"cooldown_fallback_enabled", "true", "bool", "所有渠道冷却时选最优渠道兜底(关闭则直接拒绝请求)", "true"},
 		// Debug日志配置

--- a/internal/storage/sql/metrics.go
+++ b/internal/storage/sql/metrics.go
@@ -883,7 +883,9 @@ func (s *SQLStore) GetChannelSuccessRates(ctx context.Context, since time.Time) 
 		SELECT
 			channel_id,
 			SUM(CASE WHEN status_code >= 200 AND status_code < 300 THEN 1 ELSE 0 END) AS success,
-			SUM(CASE WHEN ` + eligible + ` THEN 1 ELSE 0 END) AS total
+			SUM(CASE WHEN ` + eligible + ` THEN 1 ELSE 0 END) AS total,
+			AVG(CASE WHEN status_code >= 200 AND status_code < 300 AND first_byte_time > 0 THEN first_byte_time ELSE NULL END) AS avg_first_byte,
+			SUM(CASE WHEN status_code >= 200 AND status_code < 300 AND first_byte_time > 0 THEN 1 ELSE 0 END) AS first_byte_samples
 		FROM logs
 		WHERE minute_bucket >= ? AND minute_bucket <= ? AND channel_id > 0 AND log_source = ?
 		GROUP BY channel_id`
@@ -897,15 +899,21 @@ func (s *SQLStore) GetChannelSuccessRates(ctx context.Context, since time.Time) 
 	result := make(map[int64]model.ChannelHealthStats)
 	for rows.Next() {
 		var channelID int64
-		var success, total int64
-		if err := rows.Scan(&channelID, &success, &total); err != nil {
+		var success, total, firstByteSamples int64
+		var avgFirstByte sql.NullFloat64
+		if err := rows.Scan(&channelID, &success, &total, &avgFirstByte, &firstByteSamples); err != nil {
 			return nil, err
 		}
 		if total > 0 {
-			result[channelID] = model.ChannelHealthStats{
-				SuccessRate: float64(success) / float64(total),
-				SampleCount: total,
+			stats := model.ChannelHealthStats{
+				SuccessRate:          float64(success) / float64(total),
+				SampleCount:          total,
+				FirstByteSampleCount: firstByteSamples,
 			}
+			if avgFirstByte.Valid && firstByteSamples > 0 {
+				stats.AvgFirstByteSeconds = avgFirstByte.Float64
+			}
+			result[channelID] = stats
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Add optional channel-level first-byte (TTFB) penalty into effective priority scoring.
- Formula: `P_eff = Priority - fail_penalty - relative_TTFB_penalty` where relative slowness is measured against the **median TTFB of current route candidates**.
- Defaults **off** (`enable_ttfb_score=false`); requires `enable_health_score=true` to take effect.
- Multi-URL selection remains unchanged (`1/TTFB_EWMA`).

### Formula (plain text)
```text
P_eff = Priority
      - (1 - success_rate) * 100 * min(1, N_req / 20)
      - min(max(L_ch / L_med - 1, 0), 2) * 20 * min(1, N_ttfb / 10)
```
- Only penalizes slower-than-median channels (no reward for being faster).
- Caps extreme slowness at 3× median (`ttfb_max_slow_ratio=2` on `(s-1)`).
- Low sample counts reduce penalty via confidence.

### Settings
| Key | Default | Notes |
|-----|---------|-------|
| `enable_ttfb_score` | `false` | Master switch for TTFB penalty |
| `ttfb_penalty_weight` | `20` | Weight for full-confidence 2×-median case |
| `ttfb_max_slow_ratio` | `2` | Cap for `(s-1)` |
| `ttfb_min_confident_sample` | `10` | Full TTFB confidence threshold |

Reuses existing health window / update interval settings.

## Test plan
- [x] `go test -tags sonic ./internal/model -run DefaultHealthScore`
- [x] `go test -tags sonic ./internal/app -run 'MedianFloat64|CalculateEffectivePriority_TTFB|EffPriorityBucket'`
- [x] `go test -tags sonic ./internal/storage/sql -run Metrics_Basic`
- [ ] Enable `enable_health_score` + `enable_ttfb_score` on a multi-channel model pool and confirm slower TTFB channels rank lower without overriding manual Priority extremes.

## Notes
- Single-commit PR based on latest `master`.
- No protocol-engine or deploy-path changes included.