### PR TITLE
fix: expand token restriction tables within viewport

### DIFF
--- a/web/assets/css/tokens.css
+++ b/web/assets/css/tokens.css
@@ -569,6 +569,13 @@
       display: flex;
       flex-direction: column;
       min-height: min(680px, calc(100vh - 32px));
+      max-height: calc(100vh - 32px);
+      margin: 16px auto;
+      overflow: hidden;
+    }
+    .token-edit-modal .modal-header,
+    .token-edit-modal .modal-footer {
+      flex-shrink: 0;
     }
     .token-edit-body {
       padding-top: 12px;
@@ -577,6 +584,7 @@
       flex: 1 1 auto;
       flex-direction: column;
       gap: 12px;
+      min-height: 0;
       overflow: hidden;
     }
     .token-edit-layout {
@@ -584,6 +592,7 @@
       grid-template-columns: 320px minmax(0, 1fr);
       align-items: stretch;
       gap: 12px;
+      min-height: 0;
     }
     .token-edit-sidebar {
       display: flex;
@@ -736,7 +745,9 @@
     .token-edit-channels-table {
       flex: 1 1 auto;
       min-height: 0;
+      max-height: none;
       overflow-y: auto;
+      overscroll-behavior: contain;
       border: 1px solid var(--neutral-200);
       border-radius: 6px;
     }
@@ -775,7 +786,9 @@
     .token-edit-models-table {
       flex: 1 1 auto;
       min-height: 0;
+      max-height: none;
       overflow-y: auto;
+      overscroll-behavior: contain;
       border: 1px solid var(--neutral-200);
       border-radius: 6px;
     }


### PR DESCRIPTION
Token edit channel/model lists were capped at a few rows on large screens, while unlimited growth pushed the dialog past the browser bottom. Let restriction tables use available height and keep the edit modal within the viewport with internal scrolling.