### PR TITLE
fix(channels): 修复手机端失败详情横向溢出

### DIFF
--- a/web/assets/css/channels.css
+++ b/web/assets/css/channels.css
@@ -3629,6 +3629,8 @@
       .channel-table .ch-col-last-success .ch-last-request {
         max-width: 100%;
         min-width: 0;
+        flex-wrap: wrap;
+        justify-content: flex-end;
       }
 
       .channel-table .ch-last-request__panel {

--- a/web/assets/css/channels.css
+++ b/web/assets/css/channels.css
@@ -3530,6 +3530,7 @@
       .channel-table .ch-col-last-success {
         order: 13;
         grid-column: 1 / -1;
+        flex-wrap: wrap;
       }
 
       .channel-table .ch-col-duration {
@@ -3609,10 +3610,12 @@
       .channel-table .ch-col-last-success .ch-last-request-slot {
         display: flex;
         justify-content: flex-end;
+        flex: 1 0 100%;
+        width: 100%;
         min-width: 0;
-        max-width: min(65%, 420px);
+        max-width: 100%;
         margin-top: 0;
-        margin-left: auto;
+        margin-left: 0;
       }
 
       .channel-table .ch-last-request-slot--desktop {
@@ -3626,6 +3629,13 @@
       .channel-table .ch-col-last-success .ch-last-request {
         max-width: 100%;
         min-width: 0;
+      }
+
+      .channel-table .ch-last-request__panel {
+        left: auto;
+        right: 0;
+        max-width: calc(100vw - 48px);
+        box-sizing: border-box;
       }
 
       .channel-table .ch-col-priority .ch-priority-stack {

--- a/web/assets/js/channels-mobile-layout.test.js
+++ b/web/assets/js/channels-mobile-layout.test.js
@@ -44,6 +44,11 @@ test('mobile last-request summary and detail panel stay inside the channel card 
   );
   assert.match(
     mobileCss,
+    /\.channel-table \.ch-col-last-success \.ch-last-request\s*{[^}]*flex-wrap:\s*wrap;[^}]*justify-content:\s*flex-end;/s,
+    'the failure summary items must wrap instead of overflowing on very narrow viewports',
+  );
+  assert.match(
+    mobileCss,
     /\.channel-table \.ch-last-request__panel\s*{[^}]*left:\s*auto;[^}]*right:\s*0;[^}]*max-width:\s*calc\(100vw - 48px\);/s,
     'the expanded detail panel must open toward the viewport interior',
   );

--- a/web/assets/js/channels-mobile-layout.test.js
+++ b/web/assets/js/channels-mobile-layout.test.js
@@ -1,0 +1,50 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const css = fs.readFileSync(path.join(__dirname, '..', 'css', 'channels.css'), 'utf8');
+
+function extractBalancedBlock(source, openBraceIndex) {
+  let depth = 0;
+  for (let i = openBraceIndex; i < source.length; i += 1) {
+    if (source[i] === '{') depth += 1;
+    if (source[i] === '}') {
+      depth -= 1;
+      if (depth === 0) return source.slice(openBraceIndex + 1, i);
+    }
+  }
+  throw new Error('Unclosed CSS block');
+}
+
+function mobileChannelTableCss(source) {
+  const mediaStart = '@media (max-width: 768px)';
+  let cursor = 0;
+  while ((cursor = source.indexOf(mediaStart, cursor)) !== -1) {
+    const openBrace = source.indexOf('{', cursor + mediaStart.length);
+    const block = extractBalancedBlock(source, openBrace);
+    if (block.includes('.channel-table .ch-col-last-success')) return block;
+    cursor = openBrace + block.length + 2;
+  }
+  throw new Error('Mobile channel table media block not found');
+}
+
+test('mobile last-request summary and detail panel stay inside the channel card viewport', () => {
+  const mobileCss = mobileChannelTableCss(css);
+
+  assert.match(
+    mobileCss,
+    /\.channel-table \.ch-col-last-success\s*{[^}]*flex-wrap:\s*wrap;/s,
+    'the last-success row must allow the failure summary to move to a second line',
+  );
+  assert.match(
+    mobileCss,
+    /\.channel-table \.ch-col-last-success \.ch-last-request-slot\s*{[^}]*flex:\s*1 0 100%;[^}]*width:\s*100%;[^}]*max-width:\s*100%;[^}]*margin-left:\s*0;/s,
+    'the failure summary slot must use a full-width mobile row',
+  );
+  assert.match(
+    mobileCss,
+    /\.channel-table \.ch-last-request__panel\s*{[^}]*left:\s*auto;[^}]*right:\s*0;[^}]*max-width:\s*calc\(100vw - 48px\);/s,
+    'the expanded detail panel must open toward the viewport interior',
+  );
+});


### PR DESCRIPTION
## 问题

手机端渠道卡片中，“最后成功”一行把失败摘要限制在 65% 宽度内且不换行；展开详情时，绝对定位面板又从靠右的 `summary` 向右展开，导致整页出现横向溢出。

390px 视口回归夹具中，修复前页面 `scrollWidth` 为 666px，详情面板右边界为 665.6px。

## 修复

- 允许“最后成功”单元格换行
- 将失败摘要放到移动端全宽第二行
- 详情面板改为从右侧锚定并限制在视口宽度内
- 增加移动端布局回归测试

## 验证

- `node --test web/assets/js/*.test.js`：47/47 通过
- Docker 镜像构建成功，候选容器健康检查通过
- 390px 视口：修复后 `scrollWidth` 375px，详情面板左右边界 1.0px / 328.0px，完全位于视口内
