### PR TITLE
fix(web): preserve custom token expiry timezone

### DIFF
--- a/web/assets/js/token-expiry.js
+++ b/web/assets/js/token-expiry.js
@@ -21,5 +21,12 @@
     ].join(':');
   }
 
-  return { formatDateTimeLocal };
+  function buildUpdatePayload(initial, current, expiresAt) {
+    const unchanged = initial.type === current.type &&
+      (current.type !== 'custom' || initial.value === current.value);
+
+    return unchanged ? {} : { expires_at: expiresAt };
+  }
+
+  return { formatDateTimeLocal, buildUpdatePayload };
 });

--- a/web/assets/js/token-expiry.js
+++ b/web/assets/js/token-expiry.js
@@ -1,0 +1,25 @@
+(function (root, factory) {
+  const api = factory();
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  if (root) root.TokenExpiry = api;
+})(typeof window !== 'undefined' ? window : globalThis, function () {
+  function pad(value) {
+    return String(value).padStart(2, '0');
+  }
+
+  function formatDateTimeLocal(value) {
+    const date = value instanceof Date ? value : new Date(value);
+    if (Number.isNaN(date.getTime())) return '';
+
+    return [
+      date.getFullYear(),
+      pad(date.getMonth() + 1),
+      pad(date.getDate())
+    ].join('-') + 'T' + [
+      pad(date.getHours()),
+      pad(date.getMinutes())
+    ].join(':');
+  }
+
+  return { formatDateTimeLocal };
+});

--- a/web/assets/js/token-expiry.test.js
+++ b/web/assets/js/token-expiry.test.js
@@ -1,0 +1,20 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const TokenExpiry = require('./token-expiry.js');
+
+test('custom token expiry retains its instant when reopened in UTC+8', () => {
+  const previousTZ = process.env.TZ;
+  process.env.TZ = 'Asia/Shanghai';
+
+  try {
+    const expiresAt = Date.UTC(2026, 7, 13, 16, 1);
+    const controlValue = TokenExpiry.formatDateTimeLocal(expiresAt);
+
+    assert.equal(controlValue, '2026-08-14T00:01');
+    assert.equal(new Date(controlValue).getTime(), expiresAt);
+  } finally {
+    if (previousTZ === undefined) delete process.env.TZ;
+    else process.env.TZ = previousTZ;
+  }
+});

--- a/web/assets/js/token-expiry.test.js
+++ b/web/assets/js/token-expiry.test.js
@@ -3,18 +3,69 @@ const assert = require('node:assert/strict');
 
 const TokenExpiry = require('./token-expiry.js');
 
-test('custom token expiry retains its instant when reopened in UTC+8', () => {
+function withTimezone(timezone, fn) {
   const previousTZ = process.env.TZ;
-  process.env.TZ = 'Asia/Shanghai';
+  process.env.TZ = timezone;
 
   try {
-    const expiresAt = Date.UTC(2026, 7, 13, 16, 1);
-    const controlValue = TokenExpiry.formatDateTimeLocal(expiresAt);
-
-    assert.equal(controlValue, '2026-08-14T00:01');
-    assert.equal(new Date(controlValue).getTime(), expiresAt);
+    fn();
   } finally {
     if (previousTZ === undefined) delete process.env.TZ;
     else process.env.TZ = previousTZ;
   }
+}
+
+test('stored token expiry is displayed in the browser local timezone', () => {
+  withTimezone('Asia/Shanghai', () => {
+    const expiresAt = Date.UTC(2026, 7, 13, 16, 1, 37, 456);
+    const controlValue = TokenExpiry.formatDateTimeLocal(expiresAt);
+
+    assert.equal(controlValue, '2026-08-14T00:01');
+  });
+});
+
+test('unchanged custom expiry is omitted from the update payload', () => {
+  withTimezone('Asia/Shanghai', () => {
+    const expiresAt = Date.UTC(2026, 7, 13, 16, 1, 37, 456);
+    const controlValue = TokenExpiry.formatDateTimeLocal(expiresAt);
+    const parsedValue = new Date(controlValue).getTime();
+
+    assert.notEqual(parsedValue, expiresAt);
+    assert.deepEqual(TokenExpiry.buildUpdatePayload(
+      { type: 'custom', value: controlValue },
+      { type: 'custom', value: controlValue },
+      parsedValue
+    ), {});
+  });
+});
+
+test('unchanged expiry in a repeated DST hour is omitted from the update payload', () => {
+  withTimezone('America/New_York', () => {
+    const expiresAt = Date.UTC(2026, 10, 1, 6, 30);
+    const controlValue = TokenExpiry.formatDateTimeLocal(expiresAt);
+    const parsedValue = new Date(controlValue).getTime();
+
+    assert.equal(controlValue, '2026-11-01T01:30');
+    assert.equal(parsedValue, expiresAt - 60 * 60 * 1000);
+    assert.deepEqual(TokenExpiry.buildUpdatePayload(
+      { type: 'custom', value: controlValue },
+      { type: 'custom', value: controlValue },
+      parsedValue
+    ), {});
+  });
+});
+
+test('changed expiry is included in the update payload', () => {
+  const expiresAt = Date.UTC(2026, 7, 15, 0, 0);
+
+  assert.deepEqual(TokenExpiry.buildUpdatePayload(
+    { type: 'custom', value: '2026-08-14T00:01' },
+    { type: 'custom', value: '2026-08-15T00:00' },
+    expiresAt
+  ), { expires_at: expiresAt });
+  assert.deepEqual(TokenExpiry.buildUpdatePayload(
+    { type: 'custom', value: '2026-08-14T00:01' },
+    { type: 'never', value: '' },
+    null
+  ), { expires_at: null });
 });

--- a/web/assets/js/tokens.js
+++ b/web/assets/js/tokens.js
@@ -728,8 +728,8 @@
       } else {
         document.getElementById('editTokenExpiry').value = 'custom';
         document.getElementById('editCustomExpiryContainer').style.display = 'block';
-        const date = new Date(token.expires_at);
-        document.getElementById('editCustomExpiry').value = date.toISOString().slice(0, 16);
+        document.getElementById('editCustomExpiry').value =
+          TokenExpiry.formatDateTimeLocal(token.expires_at);
       }
 
       // 初始化费用限额状态（2026-01新增）

--- a/web/assets/js/tokens.js
+++ b/web/assets/js/tokens.js
@@ -23,6 +23,7 @@
     let currentAllowedModelFilter = '';
     let selectedChannelsForAdd = new Set();   // 渠道选择对话框中已选的渠道ID
     let currentVisibleChannels = [];          // 当前可见的渠道列表（用于全选功能）
+    let initialEditExpiryState = { type: 'never', value: '' };
 
     // 对话框栈，用于 ESC 键层级关闭
     const modalStack = [];
@@ -722,15 +723,18 @@
       document.getElementById('editTokenValue').value = token.token || '';
       document.getElementById('editTokenDescription').value = token.description;
       document.getElementById('editTokenActive').checked = token.is_active;
+      const expiryTypeInput = document.getElementById('editTokenExpiry');
+      const customExpiryInput = document.getElementById('editCustomExpiry');
       if (!token.expires_at) {
-        document.getElementById('editTokenExpiry').value = 'never';
+        expiryTypeInput.value = 'never';
+        customExpiryInput.value = '';
         document.getElementById('editCustomExpiryContainer').style.display = 'none';
       } else {
-        document.getElementById('editTokenExpiry').value = 'custom';
+        expiryTypeInput.value = 'custom';
         document.getElementById('editCustomExpiryContainer').style.display = 'block';
-        document.getElementById('editCustomExpiry').value =
-          TokenExpiry.formatDateTimeLocal(token.expires_at);
+        customExpiryInput.value = TokenExpiry.formatDateTimeLocal(token.expires_at);
       }
+      initialEditExpiryState = { type: expiryTypeInput.value, value: customExpiryInput.value };
 
       // 初始化费用限额状态（2026-01新增）
       const costLimitInput = document.getElementById('editCostLimitUSD');
@@ -775,7 +779,9 @@
     function closeEditModal() {
       document.getElementById('editModal').style.display = 'none';
       document.getElementById('editTokenValue').value = '';
+      document.getElementById('editCustomExpiry').value = '';
       document.getElementById('editCustomExpiryContainer').style.display = 'none';
+      initialEditExpiryState = { type: 'never', value: '' };
       // 清理模型限制状态
       editAllowedModels = [];
       selectedAllowedModelIndices.clear();
@@ -807,10 +813,11 @@
         return;
       }
       const maxConcurrency = maxConcurrencyResult.value;
+      let customDate = '';
       let expiresAt = null;
       if (expiryType !== 'never') {
         if (expiryType === 'custom') {
-          const customDate = document.getElementById('editCustomExpiry').value;
+          customDate = document.getElementById('editCustomExpiry').value;
           if (!customDate) {
             window.showNotification(t('tokens.msg.selectExpiry'), 'error');
             return;
@@ -821,6 +828,11 @@
           expiresAt = Date.now() + days * 24 * 60 * 60 * 1000;
         }
       }
+      const expiryUpdate = TokenExpiry.buildUpdatePayload(
+        initialEditExpiryState,
+        { type: expiryType, value: customDate },
+        expiresAt
+      );
       try {
         await fetchDataWithAuth(`${API_BASE}/auth-tokens/${id}`, {
           method: 'PUT',
@@ -830,7 +842,7 @@
           body: JSON.stringify({
             description,
             is_active: isActive,
-            expires_at: expiresAt,
+            ...expiryUpdate,
             allowed_channel_ids: editAllowedChannelIDs,
             channel_restriction_mode: normalizeChannelRestrictionMode(editChannelRestrictionMode),
             allowed_models: editAllowedModels,  // 2026-01新增：模型限制

--- a/web/tokens.html
+++ b/web/tokens.html
@@ -19,6 +19,7 @@
   <script defer src="/web/assets/js/web-auth.js?v=__VERSION__"></script>
   <script defer src="/web/assets/js/ui.js?v=__VERSION__"></script>
   <script defer src="/web/assets/js/template-engine.js?v=__VERSION__"></script>
+  <script defer src="/web/assets/js/token-expiry.js?v=__VERSION__"></script>
   <script defer src="/web/assets/js/tokens.js?v=__VERSION__"></script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- display stored custom token expiry values in the browser local timezone
- preserve the original expiry instant when editing unrelated token settings
- add a UTC+8 regression test for the datetime-local round trip

## Tests
- node --test web/assets/js/token-expiry.test.js
- make verify-web
- git diff --check