### PR TITLE
feat(docker): bundle cursor-agent in official runtime images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS base
 
 # 安装交叉编译工具链（这层很少变，缓存命中率高）
-COPY --from=tonistiigi/xx:1.6.1 / /
+COPY --from=tonistiigi/xx:1.9.0 / /
 RUN apk add --no-cache git ca-certificates tzdata clang lld
 
 WORKDIR /app
@@ -61,21 +61,37 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     xx-verify ccload
 
 # ============================================
-# 阶段4: 运行时镜像 (最小化)
+# 阶段4: 运行时镜像
+# Cursor OAuth 推理要 spawn cursor-agent（glibc Node + linux-*-gnu addons），
+# Alpine/musl 跑不了，所以运行时用 Debian。构建阶段仍是 Alpine 静态编译。
 # ============================================
-FROM alpine:3.21
+FROM debian:bookworm-slim
 
-# 安装运行时依赖
-RUN apk --no-cache add ca-certificates tzdata
+ARG TARGETARCH
+# Keep in sync with internal/cursorauth.ClientVersion.
+ARG CURSOR_AGENT_VERSION=2026.08.11-e8db854
 
-# 创建非root用户
-RUN addgroup -g 1001 -S ccload && \
-    adduser -u 1001 -S ccload -G ccload
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        libgcc-s1 \
+        libstdc++6 \
+        tzdata \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd --gid 1001 ccload && \
+    useradd --uid 1001 --gid ccload --home-dir /app --no-create-home --shell /usr/sbin/nologin ccload
+
+COPY docker/install-cursor-agent.sh /tmp/install-cursor-agent.sh
+RUN chmod +x /tmp/install-cursor-agent.sh && \
+    TARGETARCH="${TARGETARCH}" CURSOR_AGENT_VERSION="${CURSOR_AGENT_VERSION}" /tmp/install-cursor-agent.sh && \
+    rm /tmp/install-cursor-agent.sh
 
 WORKDIR /app
 
 # 从构建阶段复制（web资源已嵌入二进制）
-COPY --from=builder /app/ccload .
+COPY --from=builder --chown=1001:1001 /app/ccload .
 
 # 创建数据目录并设置权限
 RUN mkdir -p /app/data && \
@@ -85,12 +101,15 @@ USER ccload
 
 EXPOSE 8080
 
-ENV PORT=8080 \
+ENV PATH="/opt/cursor-agent/bin:${PATH}" \
+    CURSOR_AGENT_PATH=/opt/cursor-agent/bin/cursor-agent \
+    PORT=8080 \
     SQLITE_PATH=/app/data/ccload.db \
     GIN_MODE=release \
     CCLOAD_CONTAINER=1
 
+# GNU wget --spider sends HEAD; /health only accepts GET.
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1
+    CMD wget --no-verbose --tries=1 -O /dev/null http://localhost:8080/health || exit 1
 
 CMD ["./ccload"]

--- a/README.md
+++ b/README.md
@@ -731,7 +731,9 @@ ccLoad loads the Coding Plan model catalog from the account when creating or ref
 
 #### Cursor CLI
 
-In the channel manager, choose **Cursor** and complete the browser CLI login (`loginDeepControl`), import a Cursor user API key, or paste the `accessToken` from Cursor CLI `auth.json`. Login, identity, model discovery, and quota refresh talk to `api2.cursor.sh` over HTTP. Chat still runs `cursor-agent` on the ccLoad host (`--print --trust --mode ask`), so install the Cursor CLI (`https://cursor.com/install`) and keep `cursor-agent` on `PATH` (or set `CURSOR_AGENT_PATH`).
+In the channel manager, choose **Cursor** and complete the browser CLI login (`loginDeepControl`), import a Cursor user API key, or paste the `accessToken` from Cursor CLI `auth.json`. Login, identity, model discovery, and quota refresh talk to `api2.cursor.sh` over HTTP. Chat still runs `cursor-agent` on the ccLoad host (`--print --trust --mode ask`).
+
+Official Docker images already bundle `cursor-agent` at `/opt/cursor-agent/bin/cursor-agent` (`CURSOR_AGENT_PATH`). Pull the new image and recreate the container — no extra sidecar or host CLI install. Binary and source-on-host installs still need the Cursor CLI (`https://cursor.com/install`) on `PATH` (or `CURSOR_AGENT_PATH`).
 
 Chat still uses `cursor-agent --mode ask` so Cursor does not run shell or file tools on the ccLoad host. Client `tools`, `tool_use`, `function_call`, and `tool_result` are mapped through the prompt: the model emits `<cc_tool_call>` blocks, which ccLoad translates to Anthropic `tool_use` or OpenAI `tool_calls`. Sibling names from Grok Build (`run_terminal_command`, `read_file`, `search_replace`), OpenCode (`bash`, `read`, `edit`, `apply_patch`), Codex CLI (`shell`, `apply_patch`), and Claude Code/Cursor (`Bash`, `Shell`, `ReadFile`) are rewritten to the names the connected client advertised, including argument keys (`cmd`→`command`, `path`→`file_path`/`target_file`/`filePath`). The client executes those tools and sends the results back on the next turn. This is not Cursor `AgentService/RunSSE`.
 
@@ -1145,7 +1147,7 @@ Project supports multi-arch Docker images:
   - `v2.44.1` - Exact stable version, matching the GitHub Release tag
   - `vX.Y.Z-beta.N` - Exact Beta version, matching the GitHub prerelease tag
 
-The official GHCR runtime image is Alpine-based and immutable: every release packages the already-tested `ccload-linux-amd64` and `ccload-linux-arm64` GitHub Release binaries into the matching multi-arch image. Exact version Tags are immutable release references; `latest` and `beta` are rolling aliases for the newest stable and Beta images. Containers do not check for releases or replace their binary in process; pull an exact Tag or the desired rolling alias and recreate the container.
+The official GHCR runtime image is Debian bookworm and immutable: every release packages the already-tested `ccload-linux-amd64` and `ccload-linux-arm64` GitHub Release binaries into the matching multi-arch image, and bundles `cursor-agent` so Cursor OAuth chat works without a host CLI. Exact version Tags are immutable release references; `latest` and `beta` are rolling aliases for the newest stable and Beta images. Containers do not check for releases or replace their binary in process; pull an exact Tag or the desired rolling alias and recreate the container.
 
 ### Image Tag Guide
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -748,7 +748,9 @@ ccLoad 会在创建或刷新渠道时优先读取账号的 Coding Plan 模型目
 
 #### Cursor CLI
 
-在渠道管理中选择 **Cursor**，可完成浏览器 CLI 登录（`loginDeepControl`），导入 Cursor User API Key，或粘贴 Cursor CLI `auth.json` 里的 `accessToken`。登录、身份、模型目录和额度刷新走 `api2.cursor.sh` 的 HTTP 接口。对话仍在本机调用 `cursor-agent`（`--print --trust --mode ask`），需要安装 Cursor CLI（`https://cursor.com/install`）并保证 `cursor-agent` 在 `PATH` 上（或设置 `CURSOR_AGENT_PATH`）。
+在渠道管理中选择 **Cursor**，可完成浏览器 CLI 登录（`loginDeepControl`），导入 Cursor User API Key，或粘贴 Cursor CLI `auth.json` 里的 `accessToken`。登录、身份、模型目录和额度刷新走 `api2.cursor.sh` 的 HTTP 接口。对话仍在本机调用 `cursor-agent`（`--print --trust --mode ask`）。
+
+官方 Docker 镜像已内置 `cursor-agent`（`/opt/cursor-agent/bin/cursor-agent`，`CURSOR_AGENT_PATH`）。拉取新镜像并重建容器即可，不用再装 sidecar 或在宿主机装 CLI。二进制 / 本机源码安装仍需自行安装 Cursor CLI（`https://cursor.com/install`）并保证 `cursor-agent` 在 `PATH` 上（或设置 `CURSOR_AGENT_PATH`）。
 
 对话仍用 `cursor-agent --mode ask`，避免 Cursor 在网关本机跑 shell 或写文件。客户端 `tools`、`tool_use`、`function_call`、`tool_result` 走 prompt 映射：模型输出 `<cc_tool_call>` 块，ccLoad 再译成 Anthropic `tool_use` 或 OpenAI `tool_calls`。Grok Build（`run_terminal_command`/`read_file`/`search_replace`）、OpenCode（`bash`/`read`/`edit`/`apply_patch`）、Codex CLI（`shell`/`apply_patch`）以及 Claude Code/Cursor 的别名会改写成当前客户端广告的工具名，参数键一并对齐。工具由客户端执行，下一轮把结果送回来。这不是 Cursor `AgentService/RunSSE`。
 
@@ -1178,7 +1180,7 @@ export CCLOAD_ENABLE_SQLITE_REPLICA=1
   - `v2.44.1` - 精确稳定版本，和 GitHub Release Tag 保持一致
   - `vX.Y.Z-beta.N` - 精确 Beta 版本，和 GitHub Prerelease Tag 保持一致
 
-官方 GHCR 镜像基于 Alpine，并保持不可变：每次发布都将已经通过测试的 `ccload-linux-amd64` 和 `ccload-linux-arm64` GitHub Release 二进制直接打进同版本多架构镜像。精确版本 Tag 是不可变发布引用；`latest` 和 `beta` 分别滚动指向最新稳定版和 Beta。容器不检查发布版本，也不在进程内替换二进制；拉取精确版本 Tag 或所需滚动别名后重建容器即可更新。
+官方 GHCR 镜像基于 Debian bookworm，并保持不可变：每次发布都将已经通过测试的 `ccload-linux-amd64` 和 `ccload-linux-arm64` GitHub Release 二进制直接打进同版本多架构镜像，并内置 `cursor-agent`，Docker 用户无需再在宿主机安装 Cursor CLI。精确版本 Tag 是不可变发布引用；`latest` 和 `beta` 分别滚动指向最新稳定版和 Beta。容器不检查发布版本，也不在进程内替换二进制；拉取精确版本 Tag 或所需滚动别名后重建容器即可更新。
 
 ### 镜像标签说明
 

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -24,7 +24,8 @@ services:
     volumes:
       - ccload_data:/app/data
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/health"]
+      # GNU wget --spider sends HEAD; /health only accepts GET.
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "-O", "/dev/null", "http://localhost:8080/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,8 @@ services:
     volumes:
       - ./data:/app/data
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/health"]
+      # GNU wget --spider sends HEAD; /health only accepts GET.
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "-O", "/dev/null", "http://localhost:8080/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -1,20 +1,32 @@
 # syntax=docker/dockerfile:1
-FROM --platform=$BUILDPLATFORM alpine:3.21 AS runtime-files
-
-RUN apk add --no-cache ca-certificates tzdata && \
-    addgroup -g 1001 -S ccload && \
-    adduser -u 1001 -S ccload -G ccload && \
-    mkdir -p /app/data
-
-FROM alpine:3.21
+#
+# Official GHCR runtime. The ccload binary is static, but Cursor OAuth chat
+# spawns cursor-agent, which is a glibc Node CLI plus linux-*-gnu addons.
+# Alpine/musl cannot run it, so the runtime is Debian.
+FROM debian:bookworm-slim
 
 ARG TARGETARCH
+# Keep in sync with internal/cursorauth.ClientVersion.
+ARG CURSOR_AGENT_VERSION=2026.08.11-e8db854
 
-COPY --from=runtime-files /etc/ssl/certs /etc/ssl/certs
-COPY --from=runtime-files /usr/share/zoneinfo /usr/share/zoneinfo
-COPY --from=runtime-files /etc/passwd /etc/passwd
-COPY --from=runtime-files /etc/group /etc/group
-COPY --from=runtime-files --chown=1001:1001 /app/data /app/data
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        libgcc-s1 \
+        libstdc++6 \
+        tzdata \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd --gid 1001 ccload && \
+    useradd --uid 1001 --gid ccload --home-dir /app --no-create-home --shell /usr/sbin/nologin ccload && \
+    mkdir -p /app/data && \
+    chown -R ccload:ccload /app
+
+COPY docker/install-cursor-agent.sh /tmp/install-cursor-agent.sh
+RUN chmod +x /tmp/install-cursor-agent.sh && \
+    TARGETARCH="${TARGETARCH}" CURSOR_AGENT_VERSION="${CURSOR_AGENT_VERSION}" /tmp/install-cursor-agent.sh && \
+    rm /tmp/install-cursor-agent.sh
 
 WORKDIR /app
 
@@ -24,12 +36,15 @@ USER ccload
 
 EXPOSE 8080
 
-ENV PORT=8080 \
+ENV PATH="/opt/cursor-agent/bin:${PATH}" \
+    CURSOR_AGENT_PATH=/opt/cursor-agent/bin/cursor-agent \
+    PORT=8080 \
     SQLITE_PATH=/app/data/ccload.db \
     GIN_MODE=release \
     CCLOAD_CONTAINER=1
 
+# GNU wget --spider sends HEAD; /health only accepts GET.
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1
+    CMD wget --no-verbose --tries=1 -O /dev/null http://localhost:8080/health || exit 1
 
 CMD ["./ccload"]

--- a/docker/install-cursor-agent.sh
+++ b/docker/install-cursor-agent.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Bundle cursor-agent into the runtime image. Cursor's CLI is a glibc Node
+# build (linux-*-gnu native addons), so this must run on Debian/Ubuntu, not Alpine.
+# Default version must stay in sync with internal/cursorauth.ClientVersion.
+set -eu
+
+version="${CURSOR_AGENT_VERSION:?CURSOR_AGENT_VERSION is required}"
+arch="${TARGETARCH:-$(uname -m)}"
+
+case "$arch" in
+amd64 | x86_64) cursor_arch=x64 ;;
+arm64 | aarch64) cursor_arch=arm64 ;;
+*)
+	echo "unsupported TARGETARCH=$arch (need amd64 or arm64)" >&2
+	exit 1
+	;;
+esac
+
+url="https://downloads.cursor.com/lab/${version}/linux/${cursor_arch}/agent-cli-package.tar.gz"
+dest="/opt/cursor-agent/share/versions/${version}"
+
+mkdir -p "$dest" /opt/cursor-agent/bin
+wget -qO /tmp/cursor-agent.tar.gz "$url"
+tar -xzf /tmp/cursor-agent.tar.gz -C "$dest" --strip-components=1
+rm -f /tmp/cursor-agent.tar.gz
+
+if [ ! -x "$dest/cursor-agent" ] || [ ! -x "$dest/node" ]; then
+	echo "cursor-agent package is missing executables in $dest" >&2
+	ls -la "$dest" >&2
+	exit 1
+fi
+
+ln -sf "$dest/cursor-agent" /opt/cursor-agent/bin/cursor-agent
+ln -sf "$dest/cursor-agent" /opt/cursor-agent/bin/agent
+chown -R 1001:1001 /opt/cursor-agent

--- a/internal/cursorauth/constants.go
+++ b/internal/cursorauth/constants.go
@@ -17,6 +17,8 @@ const (
 	// ClientVersion is the cursor-agent build ccLoad reports upstream.
 	// Control-plane JSON RPCs accept this CLI fingerprint; chat still
 	// requires the matching binary on PATH when inference is enabled.
+	// Official Docker images pin the same version via CURSOR_AGENT_VERSION
+	// in docker/Dockerfile.release and Dockerfile.
 	ClientVersion = "2026.08.11-e8db854"
 	// ClientType is Cursor's CLI client-type header.
 	ClientType = "cli"


### PR DESCRIPTION
## 为什么

v4.7.2 的 Cursor 渠道登录/额度走 HTTP，对话却要在 **ccLoad 进程里 spawn `cursor-agent`**。官方 GHCR 镜像是 Alpine/musl，而 Cursor CLI 是 glibc Node + `linux-*-gnu` native addon，容器里没有 CLI 时渠道测试会 503：

`cursor-agent is not installed: install the Cursor CLI from https://cursor.com/install`

二进制安装仍然可以自己装 CLI；Docker 用户现在做不到开箱即用。

## 改动

- `docker/Dockerfile.release`（GHCR 真正构建的文件）和源码 `Dockerfile` 运行时改为 **Debian bookworm-slim**
- 构建时按 `TARGETARCH` 下载与 `internal/cursorauth.ClientVersion` 对齐的 `cursor-agent`（`amd64`/`arm64`）
- 安装到 `/opt/cursor-agent`，设置 `PATH` + `CURSOR_AGENT_PATH`，仍以 uid `1001` 非 root 运行
- 健康检查改为 `wget -O /dev/null`：GNU wget `--spider` 发 HEAD，`/health` 只认 GET
- 文档：Docker 镜像已内置 CLI；本机二进制安装仍需自行 `cursor.com/install`

未改发布工作流。下次打 Tag 后 `ghcr.io/caidaoli/ccload:beta` / `:latest` 会自带 CLI，`docker compose pull && up -d` 即可用 Cursor 渠道。

## 验证

本机用 `docker/Dockerfile.release` + 现有 `ccload-linux-amd64` 构建：

- `cursor-agent --version` → `2026.08.11-e8db854`（uid 1001）
- `GET /health` 200；`wget --spider`（HEAD）404，说明必须改健康检查
- 镜像约 130MB（CLI 占大部分）

构建时只解包、不执行 `cursor-agent --version`，避免 buildx qemu 跑 Node。

## 非目标

- 不改二进制 / systemd 安装方式
- 不引入 sidecar
- 不在 Alpine 上用 gcompat 硬跑 gnu addon
