### PR TITLE
[codex] 概览增加 Z.ai、Cursor、Grok 渠道聚合

### DIFF
--- a/internal/app/admin_stats.go
+++ b/internal/app/admin_stats.go
@@ -161,7 +161,7 @@ func projectTokenStats(stats []model.StatsEntry) []model.StatsEntry {
 
 // HandlePublicSummary 获取基础统计摘要(公开端点,无需认证)
 // GET /public/summary?range=today
-// 按客户端入口协议分组统计。
+// 按客户端入口协议和渠道认证类型分组统计。
 //
 // [SECURITY NOTE] 该端点故意设计为公开访问，用于首页仪表盘展示。
 // 认证仪表盘使用 /dashboard/summary，并由 Web 身份强制作用域。
@@ -179,20 +179,27 @@ func (s *Server) HandlePublicSummary(c *gin.Context) {
 		logFilter = &filter
 	}
 
-	// 协议摘要与 RPM 相互独立，并行查询。
+	// 协议摘要、认证类型摘要与 RPM 相互独立，并行查询。
 	var (
-		stats    []model.ClientProtocolStats
-		rpmStats *model.RPMStats
-		statsErr error
-		rpmErr   error
-		wg       sync.WaitGroup
+		stats        []model.ClientProtocolStats
+		authStats    []model.AuthTypeStats
+		rpmStats     *model.RPMStats
+		statsErr     error
+		authStatsErr error
+		rpmErr       error
+		wg           sync.WaitGroup
 	)
 
-	wg.Add(2)
+	wg.Add(3)
 
 	go func() {
 		defer wg.Done()
 		stats, statsErr = s.statsCache.GetClientProtocolStats(ctx, startTime, endTime, logFilter)
+	}()
+
+	go func() {
+		defer wg.Done()
+		authStats, authStatsErr = s.statsCache.GetAuthTypeStats(ctx, startTime, endTime, logFilter)
 	}()
 
 	go func() {
@@ -204,6 +211,10 @@ func (s *Server) HandlePublicSummary(c *gin.Context) {
 
 	if statsErr != nil {
 		RespondError(c, http.StatusInternalServerError, statsErr)
+		return
+	}
+	if authStatsErr != nil {
+		RespondError(c, http.StatusInternalServerError, authStatsErr)
 		return
 	}
 	if rpmErr != nil {
@@ -229,6 +240,11 @@ func (s *Server) HandlePublicSummary(c *gin.Context) {
 		}
 	}
 
+	byAuthType := make(map[string]model.AuthTypeStats, len(authStats))
+	for _, stat := range authStats {
+		byAuthType[stat.AuthType] = stat
+	}
+
 	response := gin.H{
 		"total_requests":     totalSuccess + totalError,
 		"success_requests":   totalSuccess,
@@ -238,6 +254,7 @@ func (s *Server) HandlePublicSummary(c *gin.Context) {
 		"rpm_stats":          rpmStats,
 		"is_today":           isToday,
 		"by_client_protocol": byClientProtocol,
+		"by_auth_type":       byAuthType,
 	}
 
 	RespondJSON(c, http.StatusOK, response)

--- a/internal/app/admin_stats_public_test.go
+++ b/internal/app/admin_stats_public_test.go
@@ -120,6 +120,7 @@ func TestAdminStats_PublicAndCooldownEndpoints(t *testing.T) {
 				SuccessRequests  int                                  `json:"success_requests"`
 				ErrorRequests    int                                  `json:"error_requests"`
 				ByClientProtocol map[string]model.ClientProtocolStats `json:"by_client_protocol"`
+				ByAuthType       map[string]model.AuthTypeStats       `json:"by_auth_type"`
 			} `json:"data"`
 		}
 		mustUnmarshalJSON(t, w.Body.Bytes(), &resp)
@@ -162,6 +163,9 @@ func TestAdminStats_PublicAndCooldownEndpoints(t *testing.T) {
 		}
 		if _, ok := resp.Data.ByClientProtocol["codex"]; ok {
 			t.Fatalf("scheduled checks must not enter client protocol cards: %#v", resp.Data.ByClientProtocol)
+		}
+		if len(resp.Data.ByAuthType) != 0 {
+			t.Fatalf("api_key channels must not enter auth type cards: %#v", resp.Data.ByAuthType)
 		}
 	})
 
@@ -228,4 +232,172 @@ func TestAdminStats_PublicAndCooldownEndpoints(t *testing.T) {
 			t.Fatalf("version=%v, want %q", resp.Data.Version, "test-ver")
 		}
 	})
+}
+
+func TestHandlePublicSummary_AuthTypeCards(t *testing.T) {
+	server, store, cleanup := setupAdminTestServer(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	zai, err := store.CreateConfig(ctx, &model.Config{
+		Name:            "zai-plan",
+		URLs:            model.ChannelURLs{{URL: "https://zcode.z.ai/api/v1/ultra-zai/anthropic"}},
+		Priority:        1,
+		ModelEntries:    []model.ModelEntry{{Model: "glm-4.6"}},
+		Enabled:         true,
+		AuthType:        model.AuthTypeZAIOAuth,
+		OAuthCredential: `{"type":"zai","api_key":"id.secret"}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateConfig zai failed: %v", err)
+	}
+	xai, err := store.CreateConfig(ctx, &model.Config{
+		Name:            "grok-oauth",
+		URLs:            model.ChannelURLs{{URL: "https://api.x.ai/v1"}},
+		Priority:        1,
+		ModelEntries:    []model.ModelEntry{{Model: "grok-4"}},
+		Enabled:         true,
+		AuthType:        model.AuthTypeXAIOAuth,
+		OAuthCredential: `{"type":"xai","access_token":"at"}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateConfig xai failed: %v", err)
+	}
+	anthOAuth, err := store.CreateConfig(ctx, &model.Config{
+		Name:            "claude-oauth",
+		URLs:            model.ChannelURLs{{URL: "https://api.anthropic.com"}},
+		Priority:        1,
+		ModelEntries:    []model.ModelEntry{{Model: "claude-sonnet-4"}},
+		Enabled:         true,
+		AuthType:        model.AuthTypeAnthropicOAuth,
+		OAuthCredential: `{"type":"anthropic","access_token":"at"}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateConfig anthropic oauth failed: %v", err)
+	}
+
+	now := time.Now()
+	if err := store.BatchAddLogs(ctx, []*model.LogEntry{
+		{
+			Time:                     model.JSONTime{Time: now},
+			Model:                    "glm-4.6",
+			ChannelID:                zai.ID,
+			ClientProtocol:           "anthropic",
+			LogSource:                model.LogSourceProxy,
+			StatusCode:               200,
+			InputTokens:              11,
+			OutputTokens:             22,
+			CacheReadInputTokens:     4,
+			CacheCreationInputTokens: 5,
+			Cost:                     0.04,
+			CostMultiplier:           2,
+		},
+		{
+			Time:           model.JSONTime{Time: now},
+			Model:          "glm-4.6",
+			ChannelID:      zai.ID,
+			ClientProtocol: "anthropic",
+			LogSource:      model.LogSourceProxy,
+			StatusCode:     500,
+			InputTokens:    1,
+			OutputTokens:   1,
+			Cost:           0.01,
+			CostMultiplier: 2,
+		},
+		{
+			Time:                     model.JSONTime{Time: now},
+			Model:                    "grok-4",
+			ChannelID:                xai.ID,
+			ClientProtocol:           "openai",
+			LogSource:                model.LogSourceProxy,
+			StatusCode:               200,
+			InputTokens:              8,
+			OutputTokens:             9,
+			CacheReadInputTokens:     2,
+			CacheCreationInputTokens: 3,
+			Cost:                     0.02,
+			CostMultiplier:           1,
+		},
+		{
+			Time:           model.JSONTime{Time: now},
+			Model:          "grok-4",
+			ChannelID:      xai.ID,
+			ClientProtocol: "openai",
+			LogSource:      model.LogSourceScheduledCheck,
+			StatusCode:     200,
+			InputTokens:    100,
+			Cost:           1,
+			CostMultiplier: 1,
+		},
+		{
+			Time:           model.JSONTime{Time: now},
+			Model:          "claude-sonnet-4",
+			ChannelID:      anthOAuth.ID,
+			ClientProtocol: "anthropic",
+			LogSource:      model.LogSourceProxy,
+			StatusCode:     200,
+			InputTokens:    7,
+			OutputTokens:   7,
+			Cost:           0.07,
+			CostMultiplier: 1,
+		},
+	}); err != nil {
+		t.Fatalf("BatchAddLogs failed: %v", err)
+	}
+
+	c, w := newTestContext(t, newRequest(http.MethodGet, "/public/summary?range=today", nil))
+	server.HandlePublicSummary(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d, want %d, body=%s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp struct {
+		Success bool `json:"success"`
+		Data    struct {
+			ByClientProtocol map[string]model.ClientProtocolStats `json:"by_client_protocol"`
+			ByAuthType       map[string]model.AuthTypeStats       `json:"by_auth_type"`
+		} `json:"data"`
+	}
+	mustUnmarshalJSON(t, w.Body.Bytes(), &resp)
+	if !resp.Success {
+		t.Fatalf("expected success=true, body=%s", w.Body.String())
+	}
+
+	zaiTS, ok := resp.Data.ByAuthType[model.AuthTypeZAIOAuth]
+	if !ok {
+		t.Fatalf("expected zai_oauth in by_auth_type: %#v", resp.Data.ByAuthType)
+	}
+	if zaiTS.TotalRequests != 2 || zaiTS.SuccessRequests != 1 || zaiTS.ErrorRequests != 1 {
+		t.Fatalf("unexpected zai summary: %+v", zaiTS)
+	}
+	if zaiTS.TotalInputTokens != 12 || zaiTS.TotalOutputTokens != 23 {
+		t.Fatalf("unexpected zai tokens: %+v", zaiTS)
+	}
+	if zaiTS.TotalCacheReadTokens != 4 || zaiTS.TotalCacheCreationTokens != 5 {
+		t.Fatalf("unexpected zai cache: %+v", zaiTS)
+	}
+	if zaiTS.TotalCost != 0.05 || zaiTS.EffectiveCost != 0.10 {
+		t.Fatalf("unexpected zai cost: %+v", zaiTS)
+	}
+
+	grokTS, ok := resp.Data.ByAuthType[model.AuthTypeXAIOAuth]
+	if !ok {
+		t.Fatalf("expected xai_oauth in by_auth_type: %#v", resp.Data.ByAuthType)
+	}
+	if grokTS.TotalRequests != 1 || grokTS.SuccessRequests != 1 || grokTS.ErrorRequests != 0 {
+		t.Fatalf("scheduled checks must not enter grok card: %+v", grokTS)
+	}
+	if grokTS.TotalInputTokens != 8 || grokTS.TotalCacheCreationTokens != 3 {
+		t.Fatalf("unexpected grok tokens: %+v", grokTS)
+	}
+
+	if _, ok := resp.Data.ByAuthType[model.AuthTypeAnthropicOAuth]; ok {
+		t.Fatalf("anthropic_oauth must not get an overview card: %#v", resp.Data.ByAuthType)
+	}
+	if _, ok := resp.Data.ByAuthType[model.AuthTypeCursorOAuth]; ok {
+		t.Fatalf("empty cursor_oauth must not appear as a card: %#v", resp.Data.ByAuthType)
+	}
+	if anthTS := resp.Data.ByClientProtocol["anthropic"]; anthTS.TotalRequests != 3 {
+		t.Fatalf("zai + anthropic oauth client traffic should remain on the Claude Code card: %+v", anthTS)
+	}
 }

--- a/internal/app/stats_cache.go
+++ b/internal/app/stats_cache.go
@@ -187,6 +187,29 @@ func (sc *StatsCache) GetClientProtocolStats(ctx context.Context, startTime, end
 	return result, nil
 }
 
+// GetAuthTypeStats 获取按渠道认证类型聚合的首页统计（带缓存）。
+func (sc *StatsCache) GetAuthTypeStats(ctx context.Context, startTime, endTime time.Time, filter *model.LogFilter) ([]model.AuthTypeStats, error) {
+	key := buildCacheKey("auth_type_stats", startTime, endTime, filter)
+
+	if cached, ok := sc.cache.Load(key); ok {
+		cs := cached.(*cachedStats)
+		if time.Now().Before(cs.expiry) {
+			return cs.data.([]model.AuthTypeStats), nil
+		}
+	}
+
+	result, err := sc.store.GetAuthTypeStats(ctx, startTime, endTime, filter)
+	if err != nil {
+		return nil, err
+	}
+
+	sc.storeCache(key, &cachedStats{
+		data:   result,
+		expiry: time.Now().Add(calculateTTL(endTime)),
+	})
+	return result, nil
+}
+
 // GetRPMStats 获取 RPM 统计（带缓存）
 func (sc *StatsCache) GetRPMStats(ctx context.Context, startTime, endTime time.Time, filter *model.LogFilter, isToday bool) (*model.RPMStats, error) {
 	key := buildCacheKey("rpm", startTime, endTime, filter)

--- a/internal/model/stats.go
+++ b/internal/model/stats.go
@@ -101,6 +101,25 @@ type ClientProtocolStats struct {
 	EffectiveCost            float64 `json:"effective_cost"`
 }
 
+// AuthTypeStats 按渠道认证类型聚合首页统计。
+type AuthTypeStats struct {
+	AuthType                 string  `json:"auth_type"`
+	TotalRequests            int     `json:"total_requests"`
+	SuccessRequests          int     `json:"success_requests"`
+	ErrorRequests            int     `json:"error_requests"`
+	TotalInputTokens         int64   `json:"total_input_tokens,omitempty"`
+	TotalOutputTokens        int64   `json:"total_output_tokens,omitempty"`
+	TotalCacheReadTokens     int64   `json:"total_cache_read_tokens,omitempty"`
+	TotalCacheCreationTokens int64   `json:"total_cache_creation_tokens,omitempty"`
+	TotalCost                float64 `json:"total_cost,omitempty"`
+	EffectiveCost            float64 `json:"effective_cost"`
+}
+
+// OverviewChannelAuthTypes is the extra homepage grouping beyond client protocols.
+func OverviewChannelAuthTypes() []string {
+	return []string{AuthTypeZAIOAuth, AuthTypeCursorOAuth, AuthTypeXAIOAuth}
+}
+
 // RPMStats 包含RPM/QPS相关的统计数据
 type RPMStats struct {
 	PeakRPM   float64 `json:"peak_rpm"`   // 峰值RPM（每分钟最大请求数）

--- a/internal/storage/hybrid_store.go
+++ b/internal/storage/hybrid_store.go
@@ -741,6 +741,12 @@ func (h *HybridStore) GetClientProtocolStats(ctx context.Context, startTime, end
 	})
 }
 
+func (h *HybridStore) GetAuthTypeStats(ctx context.Context, startTime, endTime time.Time, filter *model.LogFilter) ([]model.AuthTypeStats, error) {
+	return readAnalytics(h, "GetAuthTypeStats", func(store *sqlstore.SQLStore) ([]model.AuthTypeStats, error) {
+		return store.GetAuthTypeStats(ctx, startTime, endTime, filter)
+	})
+}
+
 func (h *HybridStore) GetRPMStats(ctx context.Context, startTime, endTime time.Time, filter *model.LogFilter, isToday bool) (*model.RPMStats, error) {
 	return readAnalytics(h, "GetRPMStats", func(store *sqlstore.SQLStore) (*model.RPMStats, error) {
 		return store.GetRPMStats(ctx, startTime, endTime, filter, isToday)

--- a/internal/storage/sql/metrics.go
+++ b/internal/storage/sql/metrics.go
@@ -669,6 +669,78 @@ func (s *SQLStore) GetClientProtocolStats(ctx context.Context, startTime, endTim
 	return stats, nil
 }
 
+func overviewAuthTypeValues() []any {
+	types := model.OverviewChannelAuthTypes()
+	values := make([]any, 0, len(types))
+	for _, authType := range types {
+		values = append(values, authType)
+	}
+	return values
+}
+
+// GetAuthTypeStats 按渠道认证类型聚合首页统计。
+func (s *SQLStore) GetAuthTypeStats(ctx context.Context, startTime, endTime time.Time, filter *model.LogFilter) ([]model.AuthTypeStats, error) {
+	baseQuery := `
+		SELECT
+			COALESCE(channels.auth_type, '') AS auth_type,
+			SUM(CASE WHEN logs.status_code >= 200 AND logs.status_code < 300 THEN 1 ELSE 0 END) AS success,
+			SUM(CASE WHEN (logs.status_code < 200 OR logs.status_code >= 300) AND logs.status_code != 499 THEN 1 ELSE 0 END) AS error,
+			SUM(COALESCE(logs.input_tokens, 0)) AS total_input_tokens,
+			SUM(COALESCE(logs.output_tokens, 0)) AS total_output_tokens,
+			SUM(COALESCE(logs.cache_read_input_tokens, 0)) AS total_cache_read_tokens,
+			SUM(COALESCE(logs.cache_creation_input_tokens, 0)) AS total_cache_creation_tokens,
+			SUM(COALESCE(logs.cost, 0.0)) AS total_cost,
+			SUM(COALESCE(logs.cost, 0.0) * COALESCE(logs.cost_multiplier, 1)) AS effective_cost
+		FROM logs
+		INNER JOIN channels ON channels.id = logs.channel_id`
+
+	qb := NewQueryBuilder(baseQuery).
+		Where("logs.time >= ?", startTime.UnixMilli()).
+		Where("logs.time <= ?", endTime.UnixMilli()).
+		Where("logs.channel_id > 0")
+	qb.WhereIn("channels.auth_type", overviewAuthTypeValues())
+
+	isEmpty, err := s.applyChannelFilter(ctx, qb, filter)
+	if err != nil {
+		return nil, err
+	}
+	if isEmpty {
+		return []model.AuthTypeStats{}, nil
+	}
+	qb.ApplyFilter(filter)
+
+	query, args := qb.BuildWithSuffix("GROUP BY channels.auth_type ORDER BY channels.auth_type ASC")
+	rows, err := s.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	stats := make([]model.AuthTypeStats, 0)
+	for rows.Next() {
+		var entry model.AuthTypeStats
+		if err := rows.Scan(
+			&entry.AuthType,
+			&entry.SuccessRequests,
+			&entry.ErrorRequests,
+			&entry.TotalInputTokens,
+			&entry.TotalOutputTokens,
+			&entry.TotalCacheReadTokens,
+			&entry.TotalCacheCreationTokens,
+			&entry.TotalCost,
+			&entry.EffectiveCost,
+		); err != nil {
+			return nil, err
+		}
+		entry.TotalRequests = entry.SuccessRequests + entry.ErrorRequests
+		stats = append(stats, entry)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return stats, nil
+}
+
 // GetRPMStats 获取RPM/QPS统计数据（峰值、平均、最近一分钟）
 // isToday参数控制是否计算最近一分钟数据（仅本日有意义）
 // [FIX] 2025-12: 排除499（客户端取消）避免污染RPM统计

--- a/internal/storage/sql/metrics_auth_type_test.go
+++ b/internal/storage/sql/metrics_auth_type_test.go
@@ -1,0 +1,159 @@
+package sql_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"ccLoad/internal/model"
+)
+
+func TestGetAuthTypeStats(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t, "metrics_auth_type.db")
+	ctx := context.Background()
+
+	zai, err := store.CreateConfig(ctx, &model.Config{
+		Name:            "zai-plan",
+		URLs:            model.ChannelURLs{{URL: "https://zcode.z.ai/api/v1/ultra-zai/anthropic"}},
+		Priority:        1,
+		Enabled:         true,
+		AuthType:        model.AuthTypeZAIOAuth,
+		OAuthCredential: `{"type":"zai","api_key":"id.secret"}`,
+		ModelEntries:    []model.ModelEntry{{Model: "glm-4.6"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateConfig zai: %v", err)
+	}
+	xai, err := store.CreateConfig(ctx, &model.Config{
+		Name:            "grok-oauth",
+		URLs:            model.ChannelURLs{{URL: "https://api.x.ai/v1"}},
+		Priority:        1,
+		Enabled:         true,
+		AuthType:        model.AuthTypeXAIOAuth,
+		OAuthCredential: `{"type":"xai","access_token":"at"}`,
+		ModelEntries:    []model.ModelEntry{{Model: "grok-4"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateConfig xai: %v", err)
+	}
+	cursor, err := store.CreateConfig(ctx, &model.Config{
+		Name:            "cursor-cli",
+		URLs:            model.ChannelURLs{{URL: "https://api.cursor.com"}},
+		Priority:        1,
+		Enabled:         true,
+		AuthType:        model.AuthTypeCursorOAuth,
+		OAuthCredential: `{"type":"cursor","access_token":"at"}`,
+		ModelEntries:    []model.ModelEntry{{Model: "cursor-small"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateConfig cursor: %v", err)
+	}
+	apiKeyID := createTestChannel(t, ctx, store, "plain-api")
+
+	now := time.Now()
+	start := now.Add(-time.Minute)
+	end := now.Add(time.Minute)
+	if err := store.BatchAddLogs(ctx, []*model.LogEntry{
+		{
+			Time:                     model.JSONTime{Time: now},
+			ChannelID:                zai.ID,
+			Model:                    "glm-4.6",
+			ClientProtocol:           "anthropic",
+			StatusCode:               200,
+			InputTokens:              10,
+			OutputTokens:             20,
+			CacheReadInputTokens:     3,
+			CacheCreationInputTokens: 4,
+			Cost:                     0.05,
+			CostMultiplier:           2,
+			LogSource:                model.LogSourceProxy,
+		},
+		{
+			Time:           model.JSONTime{Time: now},
+			ChannelID:      zai.ID,
+			Model:          "glm-4.6",
+			ClientProtocol: "anthropic",
+			StatusCode:     499,
+			LogSource:      model.LogSourceProxy,
+		},
+		{
+			Time:           model.JSONTime{Time: now},
+			ChannelID:      xai.ID,
+			Model:          "grok-4",
+			ClientProtocol: "openai",
+			StatusCode:     500,
+			InputTokens:    6,
+			OutputTokens:   7,
+			Cost:           0.01,
+			CostMultiplier: 1,
+			LogSource:      model.LogSourceProxy,
+		},
+		{
+			Time:           model.JSONTime{Time: now},
+			ChannelID:      cursor.ID,
+			Model:          "cursor-small",
+			ClientProtocol: "anthropic",
+			StatusCode:     200,
+			InputTokens:    4,
+			OutputTokens:   5,
+			Cost:           0.03,
+			CostMultiplier: 1,
+			LogSource:      model.LogSourceProxy,
+		},
+		{
+			Time:           model.JSONTime{Time: now},
+			ChannelID:      apiKeyID,
+			Model:          "gpt-4",
+			ClientProtocol: "openai",
+			StatusCode:     200,
+			InputTokens:    50,
+			Cost:           0.5,
+			CostMultiplier: 1,
+			LogSource:      model.LogSourceProxy,
+		},
+	}); err != nil {
+		t.Fatalf("BatchAddLogs: %v", err)
+	}
+
+	stats, err := store.GetAuthTypeStats(ctx, start, end, nil)
+	if err != nil {
+		t.Fatalf("GetAuthTypeStats: %v", err)
+	}
+	byType := map[string]model.AuthTypeStats{}
+	for _, entry := range stats {
+		byType[entry.AuthType] = entry
+	}
+	zaiTS, ok := byType[model.AuthTypeZAIOAuth]
+	if !ok {
+		t.Fatalf("missing zai_oauth: %#v", byType)
+	}
+	if zaiTS.TotalRequests != 1 || zaiTS.SuccessRequests != 1 || zaiTS.ErrorRequests != 0 {
+		t.Fatalf("499 must not count on zai card: %+v", zaiTS)
+	}
+	if zaiTS.TotalInputTokens != 10 || zaiTS.TotalCacheCreationTokens != 4 {
+		t.Fatalf("unexpected zai tokens: %+v", zaiTS)
+	}
+	if zaiTS.TotalCost != 0.05 || zaiTS.EffectiveCost != 0.10 {
+		t.Fatalf("unexpected zai cost: %+v", zaiTS)
+	}
+
+	xaiTS, ok := byType[model.AuthTypeXAIOAuth]
+	if !ok {
+		t.Fatalf("missing xai_oauth: %#v", byType)
+	}
+	if xaiTS.TotalRequests != 1 || xaiTS.SuccessRequests != 0 || xaiTS.ErrorRequests != 1 {
+		t.Fatalf("unexpected xai summary: %+v", xaiTS)
+	}
+
+	cursorTS, ok := byType[model.AuthTypeCursorOAuth]
+	if !ok {
+		t.Fatalf("missing cursor_oauth: %#v", byType)
+	}
+	if cursorTS.TotalRequests != 1 || cursorTS.SuccessRequests != 1 || cursorTS.TotalInputTokens != 4 {
+		t.Fatalf("unexpected cursor summary: %+v", cursorTS)
+	}
+	if _, ok := byType[model.AuthTypeAPIKey]; ok {
+		t.Fatalf("api_key must not appear in auth type overview: %#v", byType)
+	}
+}

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -95,6 +95,7 @@ type Store interface {
 	GetStats(ctx context.Context, startTime, endTime time.Time, filter *model.LogFilter, isToday bool) ([]model.StatsEntry, error)
 	GetStatsLite(ctx context.Context, startTime, endTime time.Time, filter *model.LogFilter) ([]model.StatsEntry, error) // 轻量版：跳过RPM计算和渠道名填充
 	GetClientProtocolStats(ctx context.Context, startTime, endTime time.Time, filter *model.LogFilter) ([]model.ClientProtocolStats, error)
+	GetAuthTypeStats(ctx context.Context, startTime, endTime time.Time, filter *model.LogFilter) ([]model.AuthTypeStats, error)
 	GetRPMStats(ctx context.Context, startTime, endTime time.Time, filter *model.LogFilter, isToday bool) (*model.RPMStats, error)
 	GetChannelSuccessRates(ctx context.Context, since time.Time) (map[int64]model.ChannelHealthStats, error)
 	GetHealthTimeline(ctx context.Context, params model.HealthTimelineParams) ([]model.HealthTimelineRow, error)

--- a/web/assets/css/styles.css
+++ b/web/assets/css/styles.css
@@ -1025,6 +1025,18 @@ body {
   background: linear-gradient(135deg, #4285f4, #1a73e8);
 }
 
+.channel-icon--zai {
+  background: linear-gradient(135deg, #0f766e, #14b8a6);
+}
+
+.channel-icon--cursor {
+  background: linear-gradient(135deg, #18181b, #3f3f46);
+}
+
+.channel-icon--grok {
+  background: linear-gradient(135deg, #ca8a04, #eab308);
+}
+
 .channel-cost {
   text-align: right;
 }

--- a/web/assets/js/index.js
+++ b/web/assets/js/index.js
@@ -1,5 +1,5 @@
     // 统计数据管理
-    let statsData = { by_client_protocol: {} };
+    let statsData = { by_client_protocol: {}, by_auth_type: {} };
 
     // 当前选中的时间范围
     let currentTimeRange = 'today';
@@ -221,14 +221,19 @@
     function updateStatsDisplay() {
       // 更新按客户端入口协议统计
       const protocolStats = statsData.by_client_protocol || {};
-      updateClientProtocolStats('anthropic', protocolStats.anthropic);
-      updateClientProtocolStats('codex', protocolStats.codex);
-      updateClientProtocolStats('openai', protocolStats.openai);
-      updateClientProtocolStats('gemini', protocolStats.gemini);
+      updateOverviewCard('anthropic', protocolStats.anthropic);
+      updateOverviewCard('codex', protocolStats.codex);
+      updateOverviewCard('openai', protocolStats.openai);
+      updateOverviewCard('gemini', protocolStats.gemini);
+
+      const authStats = statsData.by_auth_type || {};
+      updateOverviewCard('zai', authStats.zai_oauth);
+      updateOverviewCard('cursor', authStats.cursor_oauth);
+      updateOverviewCard('grok', authStats.xai_oauth);
     }
 
-    // 更新单个客户端入口协议的统计
-    function updateClientProtocolStats(type, data) {
+    // 更新单个概览卡片的统计
+    function updateOverviewCard(type, data) {
       // 始终显示所有卡片，保持界面完整性
       const card = document.getElementById(`type-${type}-card`);
       if (card) card.style.display = 'block';
@@ -248,7 +253,6 @@
       document.getElementById(`type-${type}-error`).textContent = formatNumber(errorRequests);
       document.getElementById(`type-${type}-rate`).textContent = successRate + '%';
 
-      // 所有客户端协议的Token和成本统计
       const inputTokens = data ? (data.total_input_tokens || 0) : 0;
       const outputTokens = data ? (data.total_output_tokens || 0) : 0;
       const totalCost = data ? (data.total_cost || 0) : 0;
@@ -260,18 +264,14 @@
       document.getElementById(`type-${type}-output`).textContent = formatNumber(outputTokens);
       document.getElementById(`type-${type}-cost`).innerHTML = buildCostStackHtml(totalCost, effectiveCost, { tone: 'warning', inline: true });
 
-      // Claude和Codex类型的缓存统计（缓存读+缓存创建）
-      if (type === 'anthropic' || type === 'codex') {
-        const cacheReadTokens = data ? (data.total_cache_read_tokens || 0) : 0;
-        const cacheCreateTokens = data ? (data.total_cache_creation_tokens || 0) : 0;
-        document.getElementById(`type-${type}-cache-read`).textContent = formatNumber(cacheReadTokens);
-        document.getElementById(`type-${type}-cache-create`).textContent = formatNumber(cacheCreateTokens);
-      }
+      const cacheReadTokens = data ? (data.total_cache_read_tokens || 0) : 0;
+      const cacheReadEl = document.getElementById(`type-${type}-cache-read`);
+      if (cacheReadEl) cacheReadEl.textContent = formatNumber(cacheReadTokens);
 
-      // OpenAI和Gemini类型的缓存统计（仅缓存读）
-      if (type === 'openai' || type === 'gemini') {
-        const cacheReadTokens = data ? (data.total_cache_read_tokens || 0) : 0;
-        document.getElementById(`type-${type}-cache-read`).textContent = formatNumber(cacheReadTokens);
+      const cacheCreateEl = document.getElementById(`type-${type}-cache-create`);
+      if (cacheCreateEl) {
+        const cacheCreateTokens = data ? (data.total_cache_creation_tokens || 0) : 0;
+        cacheCreateEl.textContent = formatNumber(cacheCreateTokens);
       }
     }
 

--- a/web/index.html
+++ b/web/index.html
@@ -253,6 +253,173 @@
             </div>
           </div>
         </section>
+
+        <!-- 按渠道认证类型统计 -->
+        <section class="mb-6">
+          <div class="grid grid-cols-2 animate-slide-up animate-delay-1 gap-space-3">
+            <!-- Z.ai -->
+            <div class="channel-card" id="type-zai-card">
+              <div class="channel-card-header">
+                <div class="channel-card-title">
+                  <div class="channel-icon channel-icon--zai">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M6 6h12L6 18h12"/>
+                    </svg>
+                  </div>
+                  <span>Z.ai</span>
+                </div>
+                <div class="channel-cost">
+                  <span class="cost-label" data-i18n="common.cost">成本</span>
+                  <span class="cost-value" id="type-zai-cost">$0.00</span>
+                </div>
+              </div>
+              <div class="channel-metrics">
+                <div class="metric-item">
+                  <div class="metric-value metric-total" id="type-zai-requests">0</div>
+                  <div class="metric-label" data-i18n="index.metrics.totalRequests">总请求</div>
+                </div>
+                <div class="metric-item">
+                  <div class="metric-value metric-success" id="type-zai-success">0</div>
+                  <div class="metric-label" data-i18n="index.metrics.success">成功</div>
+                </div>
+                <div class="metric-item">
+                  <div class="metric-value metric-error" id="type-zai-error">0</div>
+                  <div class="metric-label" data-i18n="index.metrics.failed">失败</div>
+                </div>
+                <div class="metric-item">
+                  <div class="metric-value metric-rate" id="type-zai-rate">0.0%</div>
+                  <div class="metric-label" data-i18n="index.metrics.successRate">成功率</div>
+                </div>
+              </div>
+              <div class="token-stats">
+                <div class="token-item">
+                  <span class="token-label" data-i18n="common.input">输入</span>
+                  <span class="token-value" id="type-zai-input">0</span>
+                </div>
+                <div class="token-item">
+                  <span class="token-label" data-i18n="common.output">输出</span>
+                  <span class="token-value" id="type-zai-output">0</span>
+                </div>
+                <div class="token-item">
+                  <span class="token-label" data-i18n="common.cacheRead">缓存读</span>
+                  <span class="token-value token-cache" id="type-zai-cache-read">0</span>
+                </div>
+                <div class="token-item">
+                  <span class="token-label" data-i18n="common.cacheCreate">缓存创</span>
+                  <span class="token-value token-cache" id="type-zai-cache-create">0</span>
+                </div>
+              </div>
+            </div>
+
+            <!-- Cursor -->
+            <div class="channel-card" id="type-cursor-card">
+              <div class="channel-card-header">
+                <div class="channel-card-title">
+                  <div class="channel-icon channel-icon--cursor">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+                      <path d="M5 3.2 20.8 13l-7.1 1.4 4.4 7.8-2.9 1.6-4.4-7.9-5.8 4z"/>
+                    </svg>
+                  </div>
+                  <span>Cursor</span>
+                </div>
+                <div class="channel-cost">
+                  <span class="cost-label" data-i18n="common.cost">成本</span>
+                  <span class="cost-value" id="type-cursor-cost">$0.00</span>
+                </div>
+              </div>
+              <div class="channel-metrics">
+                <div class="metric-item">
+                  <div class="metric-value metric-total" id="type-cursor-requests">0</div>
+                  <div class="metric-label" data-i18n="index.metrics.totalRequests">总请求</div>
+                </div>
+                <div class="metric-item">
+                  <div class="metric-value metric-success" id="type-cursor-success">0</div>
+                  <div class="metric-label" data-i18n="index.metrics.success">成功</div>
+                </div>
+                <div class="metric-item">
+                  <div class="metric-value metric-error" id="type-cursor-error">0</div>
+                  <div class="metric-label" data-i18n="index.metrics.failed">失败</div>
+                </div>
+                <div class="metric-item">
+                  <div class="metric-value metric-rate" id="type-cursor-rate">0.0%</div>
+                  <div class="metric-label" data-i18n="index.metrics.successRate">成功率</div>
+                </div>
+              </div>
+              <div class="token-stats">
+                <div class="token-item">
+                  <span class="token-label" data-i18n="common.input">输入</span>
+                  <span class="token-value" id="type-cursor-input">0</span>
+                </div>
+                <div class="token-item">
+                  <span class="token-label" data-i18n="common.output">输出</span>
+                  <span class="token-value" id="type-cursor-output">0</span>
+                </div>
+                <div class="token-item">
+                  <span class="token-label" data-i18n="common.cacheRead">缓存读</span>
+                  <span class="token-value token-cache" id="type-cursor-cache-read">0</span>
+                </div>
+                <div class="token-item">
+                  <span class="token-label" data-i18n="common.cacheCreate">缓存创</span>
+                  <span class="token-value token-cache" id="type-cursor-cache-create">0</span>
+                </div>
+              </div>
+            </div>
+
+            <!-- Grok -->
+            <div class="channel-card" id="type-grok-card">
+              <div class="channel-card-header">
+                <div class="channel-card-title">
+                  <div class="channel-icon channel-icon--grok">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+                      <path d="M12 2.2 13.7 10 21.8 12 13.7 14 12 21.8 10.3 14 2.2 12 10.3 10z"/>
+                    </svg>
+                  </div>
+                  <span>Grok</span>
+                </div>
+                <div class="channel-cost">
+                  <span class="cost-label" data-i18n="common.cost">成本</span>
+                  <span class="cost-value" id="type-grok-cost">$0.00</span>
+                </div>
+              </div>
+              <div class="channel-metrics">
+                <div class="metric-item">
+                  <div class="metric-value metric-total" id="type-grok-requests">0</div>
+                  <div class="metric-label" data-i18n="index.metrics.totalRequests">总请求</div>
+                </div>
+                <div class="metric-item">
+                  <div class="metric-value metric-success" id="type-grok-success">0</div>
+                  <div class="metric-label" data-i18n="index.metrics.success">成功</div>
+                </div>
+                <div class="metric-item">
+                  <div class="metric-value metric-error" id="type-grok-error">0</div>
+                  <div class="metric-label" data-i18n="index.metrics.failed">失败</div>
+                </div>
+                <div class="metric-item">
+                  <div class="metric-value metric-rate" id="type-grok-rate">0.0%</div>
+                  <div class="metric-label" data-i18n="index.metrics.successRate">成功率</div>
+                </div>
+              </div>
+              <div class="token-stats">
+                <div class="token-item">
+                  <span class="token-label" data-i18n="common.input">输入</span>
+                  <span class="token-value" id="type-grok-input">0</span>
+                </div>
+                <div class="token-item">
+                  <span class="token-label" data-i18n="common.output">输出</span>
+                  <span class="token-value" id="type-grok-output">0</span>
+                </div>
+                <div class="token-item">
+                  <span class="token-label" data-i18n="common.cacheRead">缓存读</span>
+                  <span class="token-value token-cache" id="type-grok-cache-read">0</span>
+                </div>
+                <div class="token-item">
+                  <span class="token-label" data-i18n="common.cacheCreate">缓存创</span>
+                  <span class="token-value token-cache" id="type-grok-cache-create">0</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
         <!-- 服务健康监测 -->
         <section class="mb-6">
           <div class="glass-card service-health-card animate-slide-up animate-delay-2" aria-labelledby="service-health-title">


### PR DESCRIPTION
## 问题

概览页只按客户端入口协议展示四张卡片（Claude Code / Codex / OpenAI / Google Gemini）。Z.ai Coding Plan、Cursor 和 Grok（xAI）渠道的用量被混在协议卡片里，无法单独查看这些渠道的请求量、成功率和成本。

## 对用户的影响

开通 Z.ai、xAI 或 Cursor 渠道后，概览无法回答「这几类渠道今天花了多少、成功率如何」。排查用量只能去渠道页或统计页逐条翻，首页失去这些新渠道的第一眼汇总。

## 根因

`/dashboard/summary` 与 `/public/summary` 只按 `logs.client_protocol` 聚合，并只把 `anthropic/codex/openai/gemini` 暴露给前端。渠道 `auth_type`（`zai_oauth` / `xai_oauth` / `cursor_oauth`）没有进入首页摘要。

## 修复

- 新增按渠道 `auth_type` 聚合的首页统计，JOIN `logs` 与 `channels`，只汇总 Z.ai、Cursor、Grok 三类认证。
- 概览页在原有协议卡片下方增加 Z.ai / Cursor / Grok 三张同结构卡片（请求、成功、失败、成功率、Token、成本）。
- 已与当前 master 变基，Cursor OAuth 渠道会直接进入 Cursor 卡片。

Z.ai / Cursor / Grok 渠道流量仍会出现在对应的客户端协议卡片上，认证类型卡片是额外维度，不是从协议卡片里拆出去。

## 验证

- `go test -tags sonic ./internal/storage/sql -run TestGetAuthTypeStats`
- `go test -tags sonic ./internal/app -run 'TestHandlePublicSummary_AuthTypeCards|TestAdminStats_PublicAndCooldownEndpoints'`
- `go test -tags sonic ./internal/model -run 'TestConfig_AuthTypeIsIndependentFromProtocol|TestConfig_CursorOAuthAuthType'`