### PR TITLE
fix(docker): use GET for healthcheck probe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -104,6 +104,6 @@ ENV PORT=8080 \
     CCLOAD_CONTAINER=1
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1
+    CMD wget -q -O /dev/null --tries=1 http://localhost:8080/health || exit 1
 
 CMD ["./ccload"]

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -24,7 +24,7 @@ services:
     volumes:
       - ccload_data:/app/data
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/health"]
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "--tries=1", "http://localhost:8080/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     volumes:
       - ./data:/app/data
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/health"]
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "--tries=1", "http://localhost:8080/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -27,6 +27,6 @@ ENV PORT=8080 \
     CCLOAD_CONTAINER=1
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1
+    CMD wget -q -O /dev/null --tries=1 http://localhost:8080/health || exit 1
 
 CMD ["./ccload"]


### PR DESCRIPTION
## Summary

The Docker healthcheck uses `wget --spider`, which sends a **HEAD** request. The `/health` endpoint only registers **GET** (`r.GET("/health", ...)` in `internal/app/server.go`), so gin returns 404 for HEAD. wget then exits with code 8 (`Remote file does not exist -- broken link!!!`) and the container is marked **unhealthy** even though the application is running fine.

## Change

Replace `wget --spider` (HEAD) with `wget -q -O /dev/null` (GET) in all four healthcheck definitions:

- `Dockerfile`
- `docker-compose.yml`
- `docker-compose.build.yml`
- `docker/Dockerfile.release`

The new command performs a real GET and exits 0 on HTTP 200, so the healthcheck reflects actual application health.

## Verification

- `wget -q -O /dev/null --tries=1 http://localhost:8080/health` inside the container exits 0
- `docker ps` shows `Up (healthy)` after recreating the container
- `docker inspect` shows `State.Health.Status = healthy`, `FailingStreak = 0`
- `/health` returns 200 with `{"success":true,"data":{"status":"ok"}}`