### PR TITLE
fix(codex): 保持 Responses 缓存前缀并线性剥离 status

### DIFF
--- a/internal/app/proxy_forward.go
+++ b/internal/app/proxy_forward.go
@@ -2158,15 +2158,11 @@ func responsesBodyForHTTPTransport(cfg *model.Config, plan protocol.TransformPla
 	return stripped
 }
 
-// sonicUseNumber 保真 round-trip：sonic 默认把 JSON 数字解码成 float64，大于 2^53
-// 的整数（seed、超长整型参数等）会丢精度；stripResponsesInputItemStatus 整份 body
-// 重编码，必须用 UseNumber。
-var sonicUseNumber = sonic.Config{UseNumber: true}.Froze()
-
 // stripResponsesInputItemStatus 剥离 Responses input item 的 status 字段。Codex HTTP
 // 上游不定义该字段（官方端点对 function_call 的 status 报 400 "Unknown parameter"），
 // 工具完成态由 call_id/function_call_output 配对重建，剥离不改变执行语义。
-// 单遍 Unmarshal/Marshal：status 数量随工具调用历史累积，逐项 DeleteBytes 是 O(k·n)。
+// 必须定点删除而不能整份 Unmarshal/Marshal：Go map 重编码会随机改变 transcript 字段
+// 顺序，破坏相邻请求共享的 prompt-cache 字节前缀。
 func stripResponsesInputItemStatus(body []byte) []byte {
 	if !bytes.Contains(body, []byte(`"status"`)) {
 		return body
@@ -2175,33 +2171,19 @@ func stripResponsesInputItemStatus(body []byte) []byte {
 	if !input.IsArray() {
 		return body
 	}
-	var root map[string]any
-	if err := sonicUseNumber.Unmarshal(body, &root); err != nil {
-		return body
-	}
-	items, ok := root["input"].([]any)
-	if !ok {
-		return body
-	}
-	changed := false
-	for _, item := range items {
-		obj, ok := item.(map[string]any)
-		if !ok {
+	items := input.Array()
+	stripped := body
+	for i := len(items) - 1; i >= 0; i-- {
+		if !items[i].IsObject() || !items[i].Get("status").Exists() {
 			continue
 		}
-		if _, has := obj["status"]; has {
-			delete(obj, "status")
-			changed = true
+		updated, err := sjson.DeleteBytes(stripped, fmt.Sprintf("input.%d.status", i))
+		if err != nil {
+			return body
 		}
+		stripped = updated
 	}
-	if !changed {
-		return body
-	}
-	out, err := sonic.Marshal(root)
-	if err != nil {
-		return body
-	}
-	return out
+	return stripped
 }
 
 func cloneRequestWithBody(req *http.Request, body []byte) *http.Request {

--- a/internal/app/proxy_forward.go
+++ b/internal/app/proxy_forward.go
@@ -2162,28 +2162,108 @@ func responsesBodyForHTTPTransport(cfg *model.Config, plan protocol.TransformPla
 // 上游不定义该字段（官方端点对 function_call 的 status 报 400 "Unknown parameter"），
 // 工具完成态由 call_id/function_call_output 配对重建，剥离不改变执行语义。
 // 必须定点删除而不能整份 Unmarshal/Marshal：Go map 重编码会随机改变 transcript 字段
-// 顺序，破坏相邻请求共享的 prompt-cache 字节前缀。
+// 顺序，破坏相邻请求共享的 prompt-cache 字节前缀。一次收集全部删除区间并压缩，
+// 避免逐字段 DeleteBytes 随历史 status 数量增长成 O(k·n)。
 func stripResponsesInputItemStatus(body []byte) []byte {
 	if !bytes.Contains(body, []byte(`"status"`)) {
 		return body
 	}
-	input := gjson.GetBytes(body, "input")
-	if !input.IsArray() {
+	if !gjson.ValidBytes(body) {
 		return body
 	}
-	items := input.Array()
-	stripped := body
-	for i := len(items) - 1; i >= 0; i-- {
-		if !items[i].IsObject() || !items[i].Get("status").Exists() {
-			continue
-		}
-		updated, err := sjson.DeleteBytes(stripped, fmt.Sprintf("input.%d.status", i))
-		if err != nil {
+	statuses := gjson.GetBytes(body, "input.#.status")
+	values := statuses.Array()
+	if len(values) == 0 || len(values) != len(statuses.Indexes) {
+		return body
+	}
+
+	type deletionRange struct {
+		start int
+		end   int
+	}
+	ranges := make([]deletionRange, 0, len(values))
+	deletedBytes := 0
+	previousEnd := 0
+	for i, value := range values {
+		start, end, ok := jsonObjectMemberDeletionRange(body, statuses.Indexes[i], len(value.Raw))
+		if !ok || start < previousEnd {
 			return body
 		}
-		stripped = updated
+		ranges = append(ranges, deletionRange{start: start, end: end})
+		deletedBytes += end - start
+		previousEnd = end
 	}
-	return stripped
+
+	stripped := make([]byte, 0, len(body)-deletedBytes)
+	previousEnd = 0
+	for _, deletion := range ranges {
+		stripped = append(stripped, body[previousEnd:deletion.start]...)
+		previousEnd = deletion.end
+	}
+	return append(stripped, body[previousEnd:]...)
+}
+
+// jsonObjectMemberDeletionRange 根据 gjson 给出的字段值位置，返回包含对象逗号的
+// 完整成员删除区间。调用方按升序一次复制未删除区间，避免反复移动整个 JSON body。
+func jsonObjectMemberDeletionRange(body []byte, valueStart, valueLength int) (int, int, bool) {
+	valueEnd := valueStart + valueLength
+	if valueStart <= 0 || valueLength <= 0 || valueEnd > len(body) {
+		return 0, 0, false
+	}
+
+	colon := skipJSONWhitespaceBackward(body, valueStart-1)
+	if colon < 0 || body[colon] != ':' {
+		return 0, 0, false
+	}
+	keyEnd := skipJSONWhitespaceBackward(body, colon-1)
+	if keyEnd < 0 || body[keyEnd] != '"' {
+		return 0, 0, false
+	}
+	const statusKey = `"status"`
+	keyStart := keyEnd + 1 - len(statusKey)
+	if keyStart < 0 || !bytes.Equal(body[keyStart:keyEnd+1], []byte(statusKey)) {
+		return 0, 0, false
+	}
+
+	afterValue := skipJSONWhitespaceForward(body, valueEnd)
+	if afterValue >= len(body) || (body[afterValue] != ',' && body[afterValue] != '}') {
+		return 0, 0, false
+	}
+	beforeKey := skipJSONWhitespaceBackward(body, keyStart-1)
+	switch {
+	case beforeKey >= 0 && body[beforeKey] == ',':
+		return beforeKey, valueEnd, true
+	case beforeKey >= 0 && body[beforeKey] == '{' && body[afterValue] == ',':
+		return keyStart, afterValue + 1, true
+	case beforeKey >= 0 && body[beforeKey] == '{' && body[afterValue] == '}':
+		return keyStart, valueEnd, true
+	default:
+		return 0, 0, false
+	}
+}
+
+func skipJSONWhitespaceBackward(body []byte, position int) int {
+	for position >= 0 {
+		switch body[position] {
+		case ' ', '\t', '\r', '\n':
+			position--
+		default:
+			return position
+		}
+	}
+	return position
+}
+
+func skipJSONWhitespaceForward(body []byte, position int) int {
+	for position < len(body) {
+		switch body[position] {
+		case ' ', '\t', '\r', '\n':
+			position++
+		default:
+			return position
+		}
+	}
+	return position
 }
 
 func cloneRequestWithBody(req *http.Request, body []byte) *http.Request {

--- a/internal/app/proxy_forward_test.go
+++ b/internal/app/proxy_forward_test.go
@@ -967,14 +967,56 @@ func TestResponsesBodyForHTTPTransport_StripsInputItemStatus(t *testing.T) {
 
 func TestStripResponsesInputItemStatusPreservesTranscriptSerialization(t *testing.T) {
 	t.Parallel()
-	body := []byte(`{"model":"gpt-5.6-sol","input":[{"type":"function_call","id":"fc_0","call_id":"call_0","name":"exec","arguments":"{\"large\":9007199254740993}","status":"completed"},{"status":"completed","type":"function_call","id":"fc_1","call_id":"call_1","name":"exec","arguments":"{}"},{"type":"message","role":"user","content":[{"type":"input_text","text":"keep"},{"type":"metadata","status":"nested-keep"}]}],"metadata":{"status":"top-level-keep"},"seed":9007199254740993}`)
-	want := []byte(`{"model":"gpt-5.6-sol","input":[{"type":"function_call","id":"fc_0","call_id":"call_0","name":"exec","arguments":"{\"large\":9007199254740993}"},{"type":"function_call","id":"fc_1","call_id":"call_1","name":"exec","arguments":"{}"},{"type":"message","role":"user","content":[{"type":"input_text","text":"keep"},{"type":"metadata","status":"nested-keep"}]}],"metadata":{"status":"top-level-keep"},"seed":9007199254740993}`)
+	body := []byte(`{"model":"gpt-5.6-sol","input":[{"type":"function_call","id":"fc_0","call_id":"call_0","name":"exec","arguments":"{\"large\":9007199254740993}","status":"completed"},{"status":"completed","type":"function_call","id":"fc_1","call_id":"call_1","name":"exec","arguments":"{}"},{"type":"function_call","status":"in_progress","id":"fc_2","call_id":"call_2","name":"exec","arguments":"{}"},{"type":"message","role":"user","content":[{"type":"input_text","text":"keep"},{"type":"metadata","status":"nested-keep"}]}],"metadata":{"status":"top-level-keep"},"seed":9007199254740993}`)
+	want := []byte(`{"model":"gpt-5.6-sol","input":[{"type":"function_call","id":"fc_0","call_id":"call_0","name":"exec","arguments":"{\"large\":9007199254740993}"},{"type":"function_call","id":"fc_1","call_id":"call_1","name":"exec","arguments":"{}"},{"type":"function_call","id":"fc_2","call_id":"call_2","name":"exec","arguments":"{}"},{"type":"message","role":"user","content":[{"type":"input_text","text":"keep"},{"type":"metadata","status":"nested-keep"}]}],"metadata":{"status":"top-level-keep"},"seed":9007199254740993}`)
 
 	for range 100 {
 		got := stripResponsesInputItemStatus(body)
 		if !bytes.Equal(got, want) {
 			t.Fatalf("status stripping changed the serialized transcript prefix:\n got: %s\nwant: %s", got, want)
 		}
+	}
+}
+
+func TestStripResponsesInputItemStatusLeavesInvalidJSONUntouched(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"input":[{"type":"function_call","status":"completed"}`)
+	if got := stripResponsesInputItemStatus(body); !bytes.Equal(got, body) {
+		t.Fatalf("invalid JSON changed: got %s", got)
+	}
+}
+
+func TestStripResponsesInputItemStatusPreservesUnrelatedWhitespace(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"input":[{ "status" : "completed" , "type" : "function_call" },{"type":"function_call" , "status" : "completed" },{"status":null}]}`)
+	want := []byte(`{"input":[{  "type" : "function_call" },{"type":"function_call"  },{}]}`)
+	if got := stripResponsesInputItemStatus(body); !bytes.Equal(got, want) {
+		t.Fatalf("status stripping changed unrelated whitespace:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func BenchmarkStripResponsesInputItemStatus(b *testing.B) {
+	for _, itemCount := range []int{1, 100, 1000} {
+		var body strings.Builder
+		body.WriteString(`{"input":[`)
+		for i := range itemCount {
+			if i > 0 {
+				body.WriteByte(',')
+			}
+			fmt.Fprintf(&body, `{"type":"function_call","id":"fc_%d","call_id":"call_%d","name":"exec","arguments":"{}","status":"completed"}`, i, i)
+		}
+		body.WriteString(`]}`)
+		payload := []byte(body.String())
+
+		b.Run(fmt.Sprintf("items_%d", itemCount), func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(payload)))
+			for b.Loop() {
+				if got := stripResponsesInputItemStatus(payload); len(got) >= len(payload) {
+					b.Fatal("status fields were not removed")
+				}
+			}
+		})
 	}
 }
 

--- a/internal/app/proxy_forward_test.go
+++ b/internal/app/proxy_forward_test.go
@@ -938,6 +938,7 @@ func TestResponsesRetryBodyForUnknownParameter_RequiresCodexResponsesScope(t *te
 func TestResponsesBodyForHTTPTransport_StripsInputItemStatus(t *testing.T) {
 	t.Parallel()
 	body := []byte(`{"model":"gpt-5.6-sol","seed":9007199254740993,"input":[{"type":"function_call","call_id":"call_1","name":"exec","arguments":"{}","status":"completed"},{"type":"message","role":"user","content":[{"type":"input_text","text":"ok"}]}]}`)
+	want := []byte(`{"model":"gpt-5.6-sol","seed":9007199254740993,"input":[{"type":"function_call","call_id":"call_1","name":"exec","arguments":"{}"},{"type":"message","role":"user","content":[{"type":"input_text","text":"ok"}]}]}`)
 	plan := protocol.TransformPlan{
 		ClientProtocol:   protocol.Codex,
 		UpstreamProtocol: protocol.Codex,
@@ -953,11 +954,27 @@ func TestResponsesBodyForHTTPTransport_StripsInputItemStatus(t *testing.T) {
 	if gjson.GetBytes(got, "seed").Raw != "9007199254740993" {
 		t.Fatalf("HTTP Codex body changed large integer: %s", got)
 	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("HTTP Codex body changed unrelated serialized bytes:\n got: %s\nwant: %s", got, want)
+	}
 
 	plan.UpstreamProtocol = protocol.OpenAI
 	got = responsesBodyForHTTPTransport(&model.Config{}, plan, body)
 	if !gjson.GetBytes(got, "input.0.status").Exists() {
 		t.Fatalf("non-Codex upstream body lost input status: %s", got)
+	}
+}
+
+func TestStripResponsesInputItemStatusPreservesTranscriptSerialization(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"model":"gpt-5.6-sol","input":[{"type":"function_call","id":"fc_0","call_id":"call_0","name":"exec","arguments":"{\"large\":9007199254740993}","status":"completed"},{"status":"completed","type":"function_call","id":"fc_1","call_id":"call_1","name":"exec","arguments":"{}"},{"type":"message","role":"user","content":[{"type":"input_text","text":"keep"},{"type":"metadata","status":"nested-keep"}]}],"metadata":{"status":"top-level-keep"},"seed":9007199254740993}`)
+	want := []byte(`{"model":"gpt-5.6-sol","input":[{"type":"function_call","id":"fc_0","call_id":"call_0","name":"exec","arguments":"{\"large\":9007199254740993}"},{"type":"function_call","id":"fc_1","call_id":"call_1","name":"exec","arguments":"{}"},{"type":"message","role":"user","content":[{"type":"input_text","text":"keep"},{"type":"metadata","status":"nested-keep"}]}],"metadata":{"status":"top-level-keep"},"seed":9007199254740993}`)
+
+	for range 100 {
+		got := stripResponsesInputItemStatus(body)
+		if !bytes.Equal(got, want) {
+			t.Fatalf("status stripping changed the serialized transcript prefix:\n got: %s\nwant: %s", got, want)
+		}
 	}
 }
 


### PR DESCRIPTION
## 修复内容

- 移除 `input[*].status` 的整份请求 `Unmarshal -> map -> Marshal` 重编码，避免 Go map 字段顺序变化破坏 prompt cache 字节前缀
- 一次定位全部直接 `input[*].status` 字段的原始字节区间，再按顺序一次复制未删除内容
- 保持已有 Responses transcript 的字段顺序、大整数、字符串转义和无关空白不变
- 只删除 input item 的直接 `status`；嵌套对象和顶层合法的 `status` 保持不变
- 非法 JSON 保持原样，继续走原有错误处理

修复 #131。

## 复杂度

设请求体大小为 `n`，直接 `input[*].status` 数量为 `k`：

- 原回归实现：整份 `Unmarshal/Marshal`，时间 O(n)，但会重排 JSON 字段
- 第一版修复：逐项 `sjson.DeleteBytes`，时间 O(k·n)，最坏 O(n²)
- 当前实现：线性校验和定位删除区间，再一次压缩输出，时间 O(n)、峰值空间 O(n)

因此，本修复没有回退到逐项删除，也没有破坏原作者‘一次处理全部 `status`、避免 O(k·n)’的性能设计意图；它只把会重排 JSON 的整份 map 重编码，替换为保持原始字节顺序的单次区间压缩。

本地 Linux/amd64（QEMU）基准：

| input item 数 | 耗时 | 吞吐 | 分配字节 |
|---:|---:|---:|---:|
| 1 | 5.01 µs | 23.75 MB/s | 736 B/op |
| 100 | 248.59 µs | 44.21 MB/s | 44,726 B/op |
| 1000 | 1.89 ms | 59.08 MB/s | 415,409 B/op |

100 到 1000 个 item 增长 10 倍时耗时增长约 7.6 倍，符合线性增长趋势。

## 验证

以下本地检查已通过：

- Responses status 定向测试，包括首/中/尾字段位置、重复处理、大整数、嵌套字段、空白和非法 JSON
- `BenchmarkStripResponsesInputItemStatus`（1/100/1000 item，`-benchmem`）
- `bash .agents/skills/sync-cliproxy-core/scripts/verify_core_scope.sh --self-test`
- `bash .agents/skills/sync-cliproxy-core/scripts/verify.sh --tests`
- `make build BINARY_NAME=/tmp/ccload-cache-fix`
- `golangci-lint run --timeout=10m ./...`（`0 issues`）
- `git diff --check`

此前本地 Docker 完整测试中，未修改的 `internal/storage` 包会在 `TestHybridStore_HighCardinalityDirtyStateCollapsesToFullReconcile` 等待条件处超时；本 PR 没有存储层改动。当前提交的 GitHub Actions 完整验证与 PostgreSQL 集成均已通过。
