### PR TITLE
fix: 防止 Anthropic SSE 零值覆盖有效 usage

### DIFF
--- a/internal/app/proxy_sse_parser.go
+++ b/internal/app/proxy_sse_parser.go
@@ -1452,60 +1452,51 @@ func (u *usageAccumulator) applyOpenAIChatUsage(usage map[string]any) {
 }
 
 // applyAnthropicOrResponsesUsage 处理Anthropic或OpenAI Responses API格式
-// 重要：Anthropic SSE流中，message_start包含input_tokens，message_delta包含cumulative output_tokens
-// 某些中间代理（如anyrouter）会在message_delta中添加input_tokens:0，需要防御性处理
+// 重要：Anthropic SSE流中，message_start/message_delta/message_stop 可能都带有累计 usage。
+// 某些中间代理会在较晚帧补全显式 0 作为占位；这些 0 不能抹掉较早的有效累计快照。
 func (u *usageAccumulator) applyAnthropicOrResponsesUsage(usage map[string]any) {
-	// input_tokens: 只有 > 0 时才覆盖（防止message_delta中的0覆盖message_start的正确值）
+	// scalar 均是累计快照：正值使用最新快照（即使比上一个正值小），0 仅视为占位。
 	if val, ok := usage["input_tokens"].(float64); ok && int(val) > 0 {
 		u.InputTokens = int(val)
 	}
-	// output_tokens: 直接覆盖（cumulative语义，后续值包含之前的累计）
-	if val, ok := usage["output_tokens"].(float64); ok {
+	if val, ok := usage["output_tokens"].(float64); ok && int(val) > 0 {
 		u.OutputTokens = int(val)
 	}
-
-	// Anthropic缓存字段
-	if val, ok := usage["cache_read_input_tokens"].(float64); ok {
+	if val, ok := usage["cache_read_input_tokens"].(float64); ok && int(val) > 0 {
 		u.CacheReadInputTokens = int(val)
 	}
-	hasAggregateCacheCreation := false
-	if val, ok := usage["cache_creation_input_tokens"].(float64); ok {
-		hasAggregateCacheCreation = true
-		u.CacheCreationInputTokens = int(val)
-	}
 
-	// Anthropic缓存细分字段 (新增2025-12)
+	aggregateCacheCreation, hasAggregateCacheCreation := usage["cache_creation_input_tokens"].(float64)
+
+	// Anthropic 缓存细分字段是一个原子快照。只要任一 bucket 为正，
+	// 就同时应用 5m/1h（包括将另一个清零），并由两者重算 aggregate。
 	hasDetailedCacheCreation := false
+	detailedCache5m := 0
+	detailedCache1h := 0
 	if cacheCreation, ok := usage["cache_creation"].(map[string]any); ok {
 		hasDetailedCacheCreation = true
-		if val, ok := cacheCreation["ephemeral_5m_input_tokens"].(float64); ok {
-			u.Cache5mInputTokens = int(val)
-		}
-		if val, ok := cacheCreation["ephemeral_1h_input_tokens"].(float64); ok {
-			u.Cache1hInputTokens = int(val)
-		}
-		// 更新兼容字段
-		u.CacheCreationInputTokens = u.Cache5mInputTokens + u.Cache1hInputTokens
+		detailedCache5m = usageInt(cacheCreation, "ephemeral_5m_input_tokens")
+		detailedCache1h = usageInt(cacheCreation, "ephemeral_1h_input_tokens")
 	}
-	if hasAggregateCacheCreation && !hasDetailedCacheCreation && u.CacheCreationInputTokens > 0 {
-		u.Cache5mInputTokens = u.CacheCreationInputTokens
+	if detailedCache5m > 0 || detailedCache1h > 0 {
+		u.setCacheCreationSnapshot(detailedCache5m, detailedCache1h)
+	} else if hasAggregateCacheCreation && int(aggregateCacheCreation) > 0 {
+		// 只有 aggregate 正值、没有权威 split 时按 5m 计价，并清掉旧 1h bucket。
+		u.setCacheCreationSnapshot(int(aggregateCacheCreation), 0)
 	}
 
 	// OpenAI Responses / Codex 缓存字段:
 	// input_tokens_details.cached_tokens      → 缓存读
 	// input_tokens_details.cache_write_tokens → 缓存建（写入）
 	if details, ok := usage["input_tokens_details"].(map[string]any); ok {
-		if val, ok := details["cached_tokens"].(float64); ok {
+		if val, ok := details["cached_tokens"].(float64); ok && int(val) > 0 {
 			u.CacheReadInputTokens = int(val)
 		}
-		// 仅在尚未拿到 Anthropic 风格 cache_creation 字段时采用 cache_write_tokens
+		// 仅在尚未拿到 Anthropic 风格 cache_creation 字段时采用 cache_write_tokens。
 		if !hasAggregateCacheCreation && !hasDetailedCacheCreation {
-			if val, ok := details["cache_write_tokens"].(float64); ok {
-				u.CacheCreationInputTokens = int(val)
-				if u.CacheCreationInputTokens > 0 {
-					// OpenAI cache write 无 5m/1h 细分，按 5m 写价（1.25x）计费
-					u.Cache5mInputTokens = u.CacheCreationInputTokens
-				}
+			if val, ok := details["cache_write_tokens"].(float64); ok && int(val) > 0 {
+				// OpenAI cache write 无 5m/1h 细分，按 5m 写价（1.25x）计费。
+				u.setCacheCreationSnapshot(int(val), 0)
 			}
 		}
 	}
@@ -1524,6 +1515,12 @@ func (u *usageAccumulator) applyAnthropicOrResponsesUsage(usage map[string]any) 
 	// NewAPI 等网关在 Claude 风格 usage 外包一层 billing_usage.openai_usage，
 	// 真实 reasoning_tokens 只在 completion_tokens_details 里。
 	u.applyBillingUsageOpenAIReasoning(usage)
+}
+
+func (u *usageAccumulator) setCacheCreationSnapshot(cache5m, cache1h int) {
+	u.Cache5mInputTokens = cache5m
+	u.Cache1hInputTokens = cache1h
+	u.CacheCreationInputTokens = cache5m + cache1h
 }
 
 // applyBillingUsageOpenAIReasoning 从 NewAPI 风格 billing_usage.openai_usage 补齐推理 token。

--- a/internal/app/proxy_sse_parser_test.go
+++ b/internal/app/proxy_sse_parser_test.go
@@ -462,6 +462,192 @@ func TestSSEUsageParser_MessageDeltaWithZeroInputTokens(t *testing.T) {
 	}
 }
 
+func TestSSEUsageParser_AnthropicPlaceholderZerosPreserveProductionUsage(t *testing.T) {
+	sseData := `event: message_start
+data: {"type":"message_start","message":{"usage":{"input_tokens":2,"output_tokens":0,"cache_read_input_tokens":169296,"cache_creation_input_tokens":2613,"cache_creation":{"ephemeral_5m_input_tokens":2613,"ephemeral_1h_input_tokens":0}}}}
+
+event: message_delta
+data: {"type":"message_delta","usage":{"input_tokens":0,"output_tokens":1378,"cache_read_input_tokens":169296,"cache_creation_input_tokens":2613,"cache_creation":{"ephemeral_5m_input_tokens":2613,"ephemeral_1h_input_tokens":0}}}
+
+event: message_stop
+data: {"type":"message_stop","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0}}}
+
+`
+
+	parser := newSSEUsageParser("anthropic")
+	feedAndAssertUsage(t, parser, sseData, 2, 1378, 169296, 2613)
+	if parser.Cache5mInputTokens != 2613 || parser.Cache1hInputTokens != 0 {
+		t.Fatalf("cache breakdown = %d/%d, want 2613/0", parser.Cache5mInputTokens, parser.Cache1hInputTokens)
+	}
+	if parser.CacheCreationInputTokens != parser.Cache5mInputTokens+parser.Cache1hInputTokens {
+		t.Fatalf("cache aggregate=%d, breakdown sum=%d", parser.CacheCreationInputTokens, parser.Cache5mInputTokens+parser.Cache1hInputTokens)
+	}
+	if !parser.IsStreamComplete() {
+		t.Fatal("message_stop 仍应标记流完成")
+	}
+}
+
+func TestSSEUsageParser_AnthropicOutputZeroThenPositive(t *testing.T) {
+	sseData := `event: message_start
+data: {"type":"message_start","message":{"usage":{"input_tokens":10,"output_tokens":0}}}
+
+event: message_delta
+data: {"type":"message_delta","usage":{"output_tokens":73}}
+
+`
+
+	feedAndAssertUsage(t, newSSEUsageParser("anthropic"), sseData, 10, 73, 0, 0)
+}
+
+func TestSSEUsageParser_AnthropicLaterPositiveSnapshotCanDecrease(t *testing.T) {
+	sseData := `event: message_delta
+data: {"type":"message_delta","usage":{"output_tokens":100,"cache_read_input_tokens":900}}
+
+event: message_delta
+data: {"type":"message_delta","usage":{"output_tokens":80,"cache_read_input_tokens":700}}
+
+`
+
+	feedAndAssertUsage(t, newSSEUsageParser("anthropic"), sseData, 0, 80, 700, 0)
+}
+
+func TestSSEUsageParser_AnthropicUsageOnlyInMessageStop(t *testing.T) {
+	sseData := `event: message_stop
+data: {"type":"message_stop","usage":{"input_tokens":12,"output_tokens":73,"cache_read_input_tokens":17558,"cache_creation_input_tokens":278}}
+
+`
+
+	parser := newSSEUsageParser("anthropic")
+	feedAndAssertUsage(t, parser, sseData, 12, 73, 17558, 278)
+	if parser.Cache5mInputTokens != 278 || parser.Cache1hInputTokens != 0 {
+		t.Fatalf("aggregate-only cache breakdown = %d/%d, want 278/0", parser.Cache5mInputTokens, parser.Cache1hInputTokens)
+	}
+	if !parser.IsStreamComplete() {
+		t.Fatal("message_stop-only usage 应保留终止语义")
+	}
+}
+
+func TestSSEUsageParser_AnthropicCacheCreationSnapshots(t *testing.T) {
+	tests := []struct {
+		name          string
+		sseData       string
+		wantAggregate int
+		want5m        int
+		want1h        int
+	}{
+		{
+			name: "1h-only snapshot clears previous 5m",
+			sseData: `event: message_start
+data: {"type":"message_start","message":{"usage":{"input_tokens":1,"cache_creation_input_tokens":500,"cache_creation":{"ephemeral_5m_input_tokens":300,"ephemeral_1h_input_tokens":200}}}}
+
+event: message_delta
+data: {"type":"message_delta","usage":{"cache_creation_input_tokens":500,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":500}}}
+
+`,
+			wantAggregate: 500,
+			want5m:        0,
+			want1h:        500,
+		},
+		{
+			name: "mixed 5m and 1h snapshot",
+			sseData: `event: message_start
+data: {"type":"message_start","message":{"usage":{"input_tokens":1,"cache_creation_input_tokens":999,"cache_creation":{"ephemeral_5m_input_tokens":300,"ephemeral_1h_input_tokens":200}}}}
+
+`,
+			wantAggregate: 500,
+			want5m:        300,
+			want1h:        200,
+		},
+		{
+			name: "all zero usage remains zero",
+			sseData: `event: message_stop
+data: {"type":"message_stop","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0}}}
+
+`,
+			wantAggregate: 0,
+			want5m:        0,
+			want1h:        0,
+		},
+		{
+			name: "aggregate-only falls back to 5m and clears 1h",
+			sseData: `event: message_start
+data: {"type":"message_start","message":{"usage":{"input_tokens":1,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":500}}}}
+
+event: message_delta
+data: {"type":"message_delta","usage":{"cache_creation_input_tokens":80}}
+
+`,
+			wantAggregate: 80,
+			want5m:        80,
+			want1h:        0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := newSSEUsageParser("anthropic")
+			if err := parser.Feed([]byte(tt.sseData)); err != nil {
+				t.Fatalf("Feed失败: %v", err)
+			}
+			if parser.CacheCreationInputTokens != tt.wantAggregate || parser.Cache5mInputTokens != tt.want5m || parser.Cache1hInputTokens != tt.want1h {
+				t.Fatalf("cache aggregate/5m/1h = %d/%d/%d, want %d/%d/%d",
+					parser.CacheCreationInputTokens, parser.Cache5mInputTokens, parser.Cache1hInputTokens,
+					tt.wantAggregate, tt.want5m, tt.want1h)
+			}
+			if parser.CacheCreationInputTokens != parser.Cache5mInputTokens+parser.Cache1hInputTokens {
+				t.Fatalf("cache aggregate=%d, breakdown sum=%d", parser.CacheCreationInputTokens, parser.Cache5mInputTokens+parser.Cache1hInputTokens)
+			}
+		})
+	}
+}
+
+func TestSSEUsageParser_AnthropicPlaceholderZerosInOversizedEvent(t *testing.T) {
+	parser := newSSEUsageParser("anthropic")
+	start := `event: message_start
+data: {"type":"message_start","message":{"usage":{"input_tokens":2,"output_tokens":1378,"cache_read_input_tokens":169296,"cache_creation_input_tokens":2613,"cache_creation":{"ephemeral_5m_input_tokens":2613,"ephemeral_1h_input_tokens":0}}}}
+
+`
+	if err := parser.Feed([]byte(start)); err != nil {
+		t.Fatalf("Feed start 失败: %v", err)
+	}
+
+	chunks := []string{
+		"event: .\n",
+		`data: {"type":".","padding":"`,
+		strings.Repeat("a", maxSSEEventSize+1),
+		`","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0}}}` + "\n\n",
+	}
+	for i, chunk := range chunks {
+		if err := parser.Feed([]byte(chunk)); err != nil {
+			t.Fatalf("Feed第%d块失败: %v", i+1, err)
+		}
+	}
+
+	feedAndAssertUsage(t, parser, "", 2, 1378, 169296, 2613)
+	if parser.CacheCreationInputTokens != parser.Cache5mInputTokens+parser.Cache1hInputTokens {
+		t.Fatalf("cache aggregate=%d, breakdown sum=%d", parser.CacheCreationInputTokens, parser.Cache5mInputTokens+parser.Cache1hInputTokens)
+	}
+}
+
+func TestSSEUsageParser_OpenAIResponsesPlaceholderZerosPreserveUsage(t *testing.T) {
+	sseData := `event: response.in_progress
+data: {"type":"response.in_progress","usage":{"input_tokens":120,"input_tokens_details":{"cached_tokens":20,"cache_write_tokens":10},"output_tokens":70}}
+
+event: response.completed
+data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":0,"input_tokens_details":{"cached_tokens":0,"cache_write_tokens":0},"output_tokens":0}}}
+
+`
+
+	parser := newSSEUsageParser("openai")
+	feedAndAssertUsage(t, parser, sseData, 90, 70, 20, 10)
+	if parser.Cache5mInputTokens != 10 || parser.Cache1hInputTokens != 0 {
+		t.Fatalf("Responses cache breakdown = %d/%d, want 10/0", parser.Cache5mInputTokens, parser.Cache1hInputTokens)
+	}
+	if !parser.IsStreamComplete() {
+		t.Fatal("response.completed 应保留终止语义")
+	}
+}
+
 // ============================================================================
 // 防御性测试：恶意输入
 // ============================================================================

--- a/web/assets/js/logs-cache-creation.test.js
+++ b/web/assets/js/logs-cache-creation.test.js
@@ -1,0 +1,40 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const escapeHtmlStub = (str) => String(str);
+global.escapeHtml = escapeHtmlStub;
+global.window = {
+  t: (key) => key,
+  escapeHtml: escapeHtmlStub,
+  initPageBootstrap() {},
+  addEventListener() {},
+};
+global.document = { addEventListener() {} };
+global.localStorage = { getItem: () => null, setItem() {}, removeItem() {} };
+
+const { getEffectiveCacheCreationTokens } = require('./logs.js');
+
+test('缓存建立显示优先使用后端 aggregate', () => {
+  assert.equal(getEffectiveCacheCreationTokens({
+    cache_creation_input_tokens: 500,
+    cache_5m_input_tokens: 300,
+    cache_1h_input_tokens: 200,
+  }), 500);
+});
+
+test('aggregate 为 0 时使用 5m+1h 明细兜底', () => {
+  assert.equal(getEffectiveCacheCreationTokens({
+    cache_creation_input_tokens: 0,
+    cache_5m_input_tokens: 2613,
+    cache_1h_input_tokens: 200,
+  }), 2813);
+});
+
+test('没有有效缓存建立数据时仍显示为 0', () => {
+  assert.equal(getEffectiveCacheCreationTokens({}), 0);
+  assert.equal(getEffectiveCacheCreationTokens({
+    cache_creation_input_tokens: 0,
+    cache_5m_input_tokens: 0,
+    cache_1h_input_tokens: 0,
+  }), 0);
+});

--- a/web/assets/js/logs.js
+++ b/web/assets/js/logs.js
@@ -546,6 +546,15 @@ function buildLogTokenDescDisplay(label) {
   return `<span class="logs-token-desc-text" title="${escapeHtml(text)}">${escapeHtml(formatLogTokenDescLabel(text))}</span>`;
 }
 
+function getEffectiveCacheCreationTokens(entry) {
+  const aggregate = Number(entry?.cache_creation_input_tokens) || 0;
+  if (aggregate > 0) return aggregate;
+
+  const cache5m = Number(entry?.cache_5m_input_tokens) || 0;
+  const cache1h = Number(entry?.cache_1h_input_tokens) || 0;
+  return cache5m + cache1h;
+}
+
 function renderLogSourceBadge(logSource) {
   switch (logSource) {
     case 'scheduled_check':
@@ -1165,7 +1174,7 @@ function renderLogs(data) {
 
     // 缓存建列
     let cacheCreationDisplay = '';
-    const total = entry.cache_creation_input_tokens || 0;
+    const total = getEffectiveCacheCreationTokens(entry);
     const cache5m = entry.cache_5m_input_tokens || 0;
     const cache1h = entry.cache_1h_input_tokens || 0;
 
@@ -2823,5 +2832,5 @@ if (typeof document !== 'undefined' && typeof document.addEventListener === 'fun
 }
 
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { isPrefixOrSuffixVariant, buildLogModelDisplay };
+  module.exports = { isPrefixOrSuffixVariant, buildLogModelDisplay, getEffectiveCacheCreationTokens };
 }


### PR DESCRIPTION
## 关联问题

Closes #133

## 修改内容

- 防止 Anthropic/OpenAI Responses 流中较晚的零值覆盖此前有效的累计 usage：
  - `input_tokens`
  - `output_tokens`
  - `cache_read_input_tokens`
  - `cache_creation_input_tokens`
- 较晚正值仍采用最新累计快照，即使比此前正值更小；没有改为 `max`。
- 保留 `message_stop` 中唯一提供有效 usage 的场景。
- 将缓存创建 5m/1h 明细作为原子快照更新：
  - 任一 bucket 为正时，同时应用两个 bucket，包括清零另一 bucket。
  - aggregate 始终由 5m + 1h 生成。
  - aggregate-only/cache-write 数据默认计入 5m，并清除旧 1h 明细。
- 日志前端在 aggregate 为零、但 5m/1h 明细存在时，使用明细之和兜底显示。

## 为什么不能使用 max

Anthropic 的 usage 是累计快照，但中转层可能对先前统计进行正值修正。因此本 PR 只忽略占位零值，仍允许后续较小的正值替换此前正值。

## 兼容性

本次变更严格限制在 Anthropic/OpenAI Responses 共用的 usage accumulator：

- OpenAI Chat Completions 的 `prompt_tokens/completion_tokens` 合并逻辑未修改。
- Gemini usage 合并逻辑未修改。
- SSE 事件过滤、非标准事件兼容和流终止逻辑未修改。
- New API 当前同样将零值视为缺失，并从已有 usage 补齐。
- Sub2API 当前的 `message_delta` 也只使用正值覆盖已有 scalar，并支持 5m/1h 分桶原子切换。

## 回归测试

新增覆盖：

- 实际生产序列：有效 usage 后跟随全零终止 usage。
- output 从零更新为正值。
- 后续较小正值仍作为最新累计快照。
- usage 只出现在 `message_stop`。
- 1h-only、5m+1h 混合及分桶切换。
- 全零响应。
- aggregate-only 缓存创建。
- 超大 SSE event scanner。
- OpenAI Responses 零值占位。
- 前端 aggregate 缺失时的 5m+1h 显示兜底。

验证结果：

- 针对性 `go test -tags sonic ./internal/app -run ...`：通过。
- `go test -tags sonic ./internal/app`：通过，604.054s。
- `make verify-web`：通过，260/260。
- `go vet -tags sonic ./internal/...`：通过。
- `go build -tags sonic`：通过。
- `git diff --check`：通过。
- 人工实际请求验证：日志中的输出、缓存读取和缓存创建已恢复。
- `go test -tags sonic ./internal/...` 遇到既有 `internal/storage` 高基数 dirty-state 测试超时；该测试单独重跑通过，未发现与本 PR 的修改路径相关。