### PR TITLE
讨论：是否在 Codex Responses 路径修复畸形 SSE 分帧

### DIFF
--- a/internal/app/proxy_forward.go
+++ b/internal/app/proxy_forward.go
@@ -513,6 +513,9 @@ func streamAndParseResponse(
 	}
 	copySSE := func(stream io.Reader, parser *sseUsageParser) error {
 		feed := makeFeed(parser)
+		if upstreamProtocol == util.ProtocolCodex {
+			stream = wrapSSEFramingRepairReader(stream)
+		}
 		if upstreamProtocol != util.ProtocolCodex && upstreamProtocol != util.ProtocolAnthropic {
 			return streamCopySSE(ctx, stream, w, feed)
 		}
@@ -1299,9 +1302,13 @@ func (s *Server) handleTranslatedStreamSuccessResponse(
 		}
 		return chunks, nil
 	}
+	streamBody := io.Reader(resp.Body)
+	if upstreamProtocol == util.ProtocolCodex {
+		streamBody = wrapSSEFramingRepairReader(resp.Body)
+	}
 	streamErr := streamTransformSSEEventsUntil(
 		reqCtx.ctx,
-		resp.Body,
+		streamBody,
 		deferredWriter,
 		func(rawEvent []byte) error {
 			parserEvent := rawEvent

--- a/internal/app/proxy_stream.go
+++ b/internal/app/proxy_stream.go
@@ -4,11 +4,179 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 )
+
+// sseFramingRepairReader restores missing SSE event boundaries for the narrow
+// Responses/Codex case where a complete typed event is immediately followed by
+// another event: line. It deliberately leaves ambiguous and non-Responses
+// frames byte-for-byte unchanged.
+type sseFramingRepairReader struct {
+	reader      *bufio.Reader
+	current     bytes.Buffer
+	pending     bytes.Buffer
+	terminalErr error
+	done        bool
+}
+
+func newSSEFramingRepairReader(src io.Reader) *sseFramingRepairReader {
+	return &sseFramingRepairReader{reader: bufio.NewReaderSize(src, SSEBufferSize)}
+}
+
+func wrapSSEFramingRepairReader(src io.Reader) io.Reader {
+	repaired := newSSEFramingRepairReader(src)
+	if closer, ok := src.(io.Closer); ok {
+		return readerWithCloser{Reader: repaired, Closer: closer}
+	}
+	return repaired
+}
+
+func (r *sseFramingRepairReader) Read(p []byte) (int, error) {
+	for {
+		if r.pending.Len() > 0 {
+			return r.pending.Read(p)
+		}
+		if r.done {
+			return 0, r.terminalErr
+		}
+
+		line, err := r.reader.ReadString('\n')
+		if len(line) > 0 {
+			if consumeErr := r.consumeLine([]byte(line)); consumeErr != nil {
+				r.done = true
+				return 0, consumeErr
+			}
+			if r.pending.Len() > 0 {
+				return r.pending.Read(p)
+			}
+		}
+		if err == nil {
+			continue
+		}
+		if err == io.EOF {
+			r.flushCurrent(shouldSplitBeforeResponsesSSEEvent(r.current.Bytes()))
+			r.done = true
+			r.terminalErr = io.EOF
+			if r.pending.Len() > 0 {
+				return r.pending.Read(p)
+			}
+			return 0, io.EOF
+		}
+
+		r.flushCurrent(false)
+		r.done = true
+		r.terminalErr = err
+		if r.pending.Len() > 0 {
+			return r.pending.Read(p)
+		}
+		return 0, err
+	}
+}
+
+func (r *sseFramingRepairReader) consumeLine(line []byte) error {
+	if isBlankSSELine(line) {
+		r.current.Write(line)
+		r.flushCurrent(false)
+		return nil
+	}
+
+	if isResponsesSSEEventLine(line) && shouldSplitBeforeResponsesSSEEvent(r.current.Bytes()) {
+		r.flushCurrent(true)
+	}
+	r.current.Write(line)
+	if r.current.Len() > maxSSEEventBytes {
+		return fmt.Errorf("SSE event exceeds %d bytes", maxSSEEventBytes)
+	}
+	return nil
+}
+
+func (r *sseFramingRepairReader) flushCurrent(addSeparator bool) {
+	if r.current.Len() == 0 {
+		return
+	}
+	if addSeparator {
+		r.current.WriteString(sseLineEnding(r.current.Bytes()))
+	}
+	_, _ = r.pending.Write(r.current.Bytes())
+	r.current.Reset()
+}
+
+func isBlankSSELine(line []byte) bool {
+	return len(bytes.TrimRight(line, "\r\n")) == 0
+}
+
+func sseLineEnding(block []byte) string {
+	if bytes.HasSuffix(block, []byte("\r\n")) {
+		return "\r\n"
+	}
+	if bytes.HasSuffix(block, []byte("\n")) {
+		return "\n"
+	}
+	if bytes.HasSuffix(block, []byte("\r")) {
+		return "\r"
+	}
+	return "\n"
+}
+
+func isResponsesSSEEventLine(line []byte) bool {
+	line = bytes.TrimRight(line, "\r\n")
+	return bytes.HasPrefix(line, []byte("event: response."))
+}
+
+func shouldSplitBeforeResponsesSSEEvent(block []byte) bool {
+	if len(block) == 0 {
+		return false
+	}
+	if isSSECommentOnly(block) {
+		return true
+	}
+
+	eventType, data := parseSSEEventChunk(block)
+	eventCount, dataCount := sseEventFieldCounts(block)
+	if eventCount != 1 || dataCount != 1 || !strings.HasPrefix(eventType, "response.") || len(data) == 0 {
+		return false
+	}
+	var payload struct {
+		Type string `json:"type"`
+	}
+	if json.Unmarshal(data, &payload) != nil {
+		return false
+	}
+	return payload.Type == eventType
+}
+
+func sseEventFieldCounts(block []byte) (eventCount, dataCount int) {
+	for _, rawLine := range bytes.Split(block, []byte{'\n'}) {
+		line := bytes.TrimRight(rawLine, "\r")
+		switch {
+		case bytes.HasPrefix(line, []byte("event:")):
+			eventCount++
+		case bytes.HasPrefix(line, []byte("data:")):
+			dataCount++
+		}
+	}
+	return eventCount, dataCount
+}
+
+func isSSECommentOnly(block []byte) bool {
+	seen := false
+	for _, rawLine := range bytes.Split(block, []byte{'\n'}) {
+		line := bytes.TrimRight(rawLine, "\r")
+		if len(line) == 0 {
+			continue
+		}
+		seen = true
+		if !bytes.HasPrefix(line, []byte(":")) {
+			return false
+		}
+	}
+	return seen
+}
 
 const maxSSEEventBytes = 50 * 1024 * 1024
 

--- a/internal/app/proxy_stream_test.go
+++ b/internal/app/proxy_stream_test.go
@@ -242,6 +242,114 @@ func TestStreamTransformSSEEventsUntil_ReassemblesLongLinesAndMultipleEvents(t *
 	}
 }
 
+func unseparatedCodexSSE() string {
+	return ": ping\n" +
+		`event: response.created` + "\n" +
+		`data: {"type":"response.created"}` + "\n" +
+		`event: response.in_progress` + "\n" +
+		`data: {"type":"response.in_progress"}` + "\n" +
+		`event: response.completed` + "\n" +
+		`data: {"type":"response.completed"}` + "\n\n"
+}
+
+func separatedCodexSSE() string {
+	return ": ping\n\n" +
+		`event: response.created` + "\n" +
+		`data: {"type":"response.created"}` + "\n\n" +
+		`event: response.in_progress` + "\n" +
+		`data: {"type":"response.in_progress"}` + "\n\n" +
+		`event: response.completed` + "\n" +
+		`data: {"type":"response.completed"}` + "\n\n"
+}
+
+func TestSSEFramingRepairReader_SplitsUnseparatedTypedEvents(t *testing.T) {
+	input := unseparatedCodexSSE()
+	want := separatedCodexSSE()
+
+	got, err := io.ReadAll(newSSEFramingRepairReader(strings.NewReader(input)))
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if string(got) != want {
+		t.Fatalf("repaired SSE = %q, want %q", got, want)
+	}
+}
+
+func TestStreamAndParseResponse_RepairsCodexSSEEventFraming(t *testing.T) {
+	input := unseparatedCodexSSE()
+	want := separatedCodexSSE()
+
+	recorder := newRecorder()
+	parser, err := streamAndParseResponse(
+		context.Background(),
+		io.NopCloser(strings.NewReader(input)),
+		recorder,
+		"text/event-stream",
+		"codex",
+		true,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("streamAndParseResponse() error = %v", err)
+	}
+	if parser == nil || !parser.IsStreamComplete() {
+		t.Fatal("repaired Codex stream should reach response.completed")
+	}
+	if got := recorder.Body.String(); got != want {
+		t.Fatalf("forwarded SSE = %q, want %q", got, want)
+	}
+}
+
+func TestStreamAndParseResponse_DoesNotRepairNonCodexSSE(t *testing.T) {
+	input := unseparatedCodexSSE()
+	recorder := newRecorder()
+	_, err := streamAndParseResponse(
+		context.Background(),
+		io.NopCloser(strings.NewReader(input)),
+		recorder,
+		"text/event-stream",
+		"openai",
+		true,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("streamAndParseResponse() error = %v", err)
+	}
+	if got := recorder.Body.String(); got != input {
+		t.Fatalf("non-Codex SSE was modified: got %q, want %q", got, input)
+	}
+}
+
+func TestSSEFramingRepairReader_PreservesMultilineDataAndAmbiguousEvents(t *testing.T) {
+	validMultiline := "event: custom\ndata: {\"type\":\"custom\",\"value\":" +
+		"\ndata: 1}\n\n"
+	ambiguous := "event: response.created\ndata: {\"type\":\"response.in_progress\"}\nevent: response.completed\ndata: {\"type\":\"response.completed\"}\n\n"
+	input := validMultiline + ambiguous
+
+	got, err := io.ReadAll(newSSEFramingRepairReader(strings.NewReader(input)))
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if string(got) != input {
+		t.Fatalf("ambiguous or multiline SSE was modified: got %q, want %q", got, input)
+	}
+}
+
+func TestSSEFramingRepairReader_PreservesCRLF(t *testing.T) {
+	input := "event: response.created\r\ndata: {\"type\":\"response.created\"}\r\n" +
+		"event: response.completed\r\ndata: {\"type\":\"response.completed\"}\r\n\r\n"
+	want := "event: response.created\r\ndata: {\"type\":\"response.created\"}\r\n\r\n" +
+		"event: response.completed\r\ndata: {\"type\":\"response.completed\"}\r\n\r\n"
+
+	got, err := io.ReadAll(newSSEFramingRepairReader(strings.NewReader(input)))
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if string(got) != want {
+		t.Fatalf("repaired CRLF SSE = %q, want %q", got, want)
+	}
+}
+
 func TestStreamTransformSSEEventsUntil_RejectsOversizedEvent(t *testing.T) {
 	reader := io.MultiReader(
 		&repeatedByteReader{remaining: maxSSEEventBytes},


### PR DESCRIPTION
## 讨论性质

这是一个**仅供讨论的 Draft PR**，暂不主张直接合并。

我不确定这种修正行为是否适合放在 ccLoad：ccLoad 的核心定位更接近协议转换/网关转发，而不是替上游修复非法响应。如果项目希望保持严格的透明透传语义，这个改动也可能被认为超出职责范围。

## 要解决的问题

部分 OpenAI Responses/Codex 兼容上游返回了格式错误的 SSE 流。典型结构类似：

```text
: ping

event: response.created
 data: {"type":"response.created"}
 event: response.in_progress
 data: {"type":"response.in_progress"}
 event: response.completed
 data: {"type":"response.completed"}
```

多个 `event:`/`data:` 事件之间缺少 SSE 要求的空行分隔。客户端（OpenAI Python SDK）会把同一个 SSE block 内的多条 `data:` 拼接后当成一个 JSON 解析，最终产生：

```text
JSONDecodeError: Extra data
```

随后客户端关闭下游连接，网关链路上可能表现为 `499 client disconnected` / `context canceled`。因此这里的 499 通常是非法 SSE 导致的下游取消症状，不是上游真的返回了 HTTP 499。

## 当前提议

在 ccLoad 的 Codex/Responses 流路径中增加一个非常窄的 framing repair reader：

- 仅作用于 `upstreamProtocol == Codex` 的 SSE 流；
- 同时覆盖原生转发和响应转换路径；
- 仅在以下条件全部满足时补一个事件分隔空行：
  - 当前 block 是单个 `response.*` 事件；
  - 当前 block 只有一条 `data:`；
  - 该 `data:` 可以独立解析为 JSON；
  - JSON 的 `type` 与 `event:` 类型一致；
  - 后面紧接着出现新的 `event: response.*`；
- 正常已有分隔的 SSE、其他协议、多行 `data:`、事件类型与 JSON 不一致或其他歧义情况保持不变；
- 不合成事件、不改变 JSON 内容、不对已输出内容做重试或 failover。

这不是把任意字节流强行按换行切开，而是只处理能够被结构性确认的“完整 typed event + 下一事件”场景。

## 为什么这可能不适合 ccLoad

这个改动确实会削弱严格的 byte-level pass-through：即使只新增空行，也不再是完全原样转发。潜在问题包括：

1. **职责边界**：上游响应非法时，网关是否应该修复，还是应该原样暴露错误并让上游负责修复？
2. **隐藏上游缺陷**：修复可能让有问题的上游继续被使用，降低问题暴露度。
3. **误判风险**：SSE 生态存在实现差异，未来可能遇到当前判定条件未覆盖的合法/半合法格式。
4. **性能与时序**：该 reader 按行保留有限 framing 状态，可能改变部分 chunk 的转发边界；虽然不会等待整个响应，但需要维护缓冲状态。
5. **可观测性**：如果修复默认开启，使用者可能不知道上游实际返回过非法 SSE。

## 当前验证

离线回放覆盖了：

- `: ping` 后缺少空行；
- 四/五组 `event/data` 粘在同一 block；
- 正常 SSE 不被修改；
- 多行 `data:` 不被修改；
- 歧义事件不被修改；
- LF、CRLF 行尾；
- Codex 流可以正常到达 `response.completed`。

在一个真实的第三方 Responses 兼容上游样本中，上游原始响应仍可观察到一个 block 内包含五组事件，但经过 ccLoad 后请求记录为 `200 ok`，没有再出现此前由该 framing 问题放大的 `499`。这只能证明该修复对已知样本有效，不能证明所有上游 SSE 都安全。

已运行的本地检查：

```text
go test -tags sonic ./internal/...
go vet -tags sonic ./internal/app
go build -tags sonic
```

## 可能的开关方向

如果维护者认为修复行为可以存在，但不应改变默认透传语义，可以考虑增加**按渠道控制的开关**，而不是全局默认启用：

- `off`：严格原样透传，默认值；
- `on`：对该渠道的 Codex/Responses SSE 启用上述窄范围修复。

按渠道控制比全局开关更适合，因为问题通常只来自某个具体上游；同时可以避免其他正常渠道的行为变化。若需要更强的可观测性，还可以在不记录请求/响应正文的前提下增加“发生过 framing repair”的计数或 debug 标记。

## 希望讨论的问题

1. 这种“只修复可确定的 SSE 事件边界”的行为是否符合 ccLoad 的职责？
2. 如果保留，是否应该默认关闭并改为按渠道 opt-in？
3. 是否应增加修复次数指标/日志，提醒使用者上游仍在返回非法流？
4. 是否有更合适的实现位置，例如专门的上游兼容层，而不是通用 proxy forwarding 路径？

在这些问题得到明确意见前，这个 PR 仅作为实现和测试样例，不建议合并到默认发布版本。
