### PR TITLE
fix(proxy): preserve Responses tool search and encrypted history

### DIFF
--- a/internal/app/admin_testing.go
+++ b/internal/app/admin_testing.go
@@ -2017,6 +2017,13 @@ func (s *Server) newTestUpstreamRequest(
 	if requestProtocol == protocol.Anthropic && isAnyrouterChannel(cfgForBuild) {
 		injectAnthropicBetaFlag(req, "context-1m-2025-08-07")
 	}
+	if isOpenCodeChannel(cfgForBuild) {
+		executionIdentity := ""
+		if testReq != nil {
+			executionIdentity = testReq.ResolveSessionID()
+		}
+		ensureOpenCodeSessionHeader(req.Header, sourceHeaders, executionIdentity)
+	}
 	// Some compatibility gateways decompress the response but leave the gzip marker.
 	// Admin tests need the wire body for diagnostics, so never negotiate compression.
 	req.Header.Set("Accept-Encoding", "identity")

--- a/internal/app/opencode_compat.go
+++ b/internal/app/opencode_compat.go
@@ -1,0 +1,143 @@
+package app
+
+import (
+	"net/http"
+	neturl "net/url"
+	"sort"
+	"strings"
+
+	"ccLoad/internal/model"
+	"ccLoad/internal/util"
+)
+
+const (
+	opencodeSessionHeader = "x-opencode-session"
+
+	// OpenCode Go's documented OpenAI-compatible base endpoint. The header is
+	// enabled only for this exact HTTPS host and path boundary.
+	opencodeHost = "opencode.ai"
+	opencodePath = "/zen/go"
+)
+
+func isOpenCodeChannel(cfg *model.Config) bool {
+	if cfg == nil {
+		return false
+	}
+	for _, endpoint := range cfg.URLs {
+		if isOpenCodeEndpoint(endpoint.URL) {
+			return true
+		}
+	}
+	return false
+}
+
+// isOpenCodeEndpoint identifies the documented OpenCode Go endpoint
+// from a configured channel URL. URL matching is structural: the host is exact
+// and the path must be /zen/go or a descendant such as /zen/go/v1/responses.
+func isOpenCodeEndpoint(raw string) bool {
+	raw = strings.TrimSpace(model.StripExactUpstreamURLMarker(raw))
+	if raw == "" {
+		return false
+	}
+	parsed, err := neturl.Parse(raw)
+	if err != nil || parsed == nil {
+		return false
+	}
+	if !strings.EqualFold(parsed.Scheme, "https") ||
+		!strings.EqualFold(parsed.Hostname(), opencodeHost) ||
+		parsed.Port() != "" || parsed.User != nil || parsed.Fragment != "" {
+		return false
+	}
+	path := parsed.EscapedPath()
+	if path == "" {
+		path = parsed.Path
+	}
+	// Reject dot segments before applying the prefix check. Otherwise a URL
+	// such as /zen/go/../other would satisfy the textual boundary while
+	// resolving to a different upstream resource.
+	for _, segment := range strings.Split(parsed.Path, "/") {
+		if segment == "." || segment == ".." {
+			return false
+		}
+	}
+	return path == opencodePath || strings.HasPrefix(path, opencodePath+"/")
+}
+
+// ensureOpenCodeSessionHeader forwards one stable session identifier
+// to OpenCode. Existing explicit values win; otherwise use a stable source
+// header or execution identity, with a request-scoped UUID as the final
+// fallback. Unrelated headers remain subject to normal forwarding rules.
+func ensureOpenCodeSessionHeader(dst, src http.Header, executionIdentity string) {
+	if dst == nil {
+		return
+	}
+	for _, name := range []string{
+		opencodeSessionHeader,
+		"x-session-id",
+		"x-session-affinity",
+		"x-litellm-session-id",
+		"x-litellm-trace-id",
+		"Session_id",
+		"Session-Id",
+		"x-client-request-id",
+	} {
+		if value := opencodeHeaderValue(dst, name); value != "" {
+			dst.Set(opencodeSessionHeader, value)
+			return
+		}
+		if value := opencodeHeaderValue(src, name); value != "" {
+			dst.Set(opencodeSessionHeader, value)
+			return
+		}
+	}
+	for _, headers := range []http.Header{dst, src} {
+		names := make([]string, 0, len(headers))
+		for name := range headers {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			values := headers[name]
+			lower := strings.ToLower(strings.TrimSpace(name))
+			if !strings.HasPrefix(lower, "x-") || !strings.HasSuffix(lower, "-session-id") || lower == "x-parent-session-id" {
+				continue
+			}
+			for _, value := range values {
+				if value = strings.TrimSpace(value); value != "" {
+					dst.Set(opencodeSessionHeader, value)
+					return
+				}
+			}
+		}
+	}
+	if value := strings.TrimSpace(executionIdentity); value != "" {
+		dst.Set(opencodeSessionHeader, value)
+		return
+	}
+	// OpenCode requires presence even when a client does not expose a session
+	// identity. This fallback is request-scoped and never persisted.
+	dst.Set(opencodeSessionHeader, util.NewUUIDv4())
+}
+
+func opencodeHeaderValue(headers http.Header, name string) string {
+	if headers == nil {
+		return ""
+	}
+	names := make([]string, 0, len(headers))
+	for headerName := range headers {
+		if !strings.EqualFold(strings.TrimSpace(headerName), name) {
+			continue
+		}
+		names = append(names, headerName)
+	}
+	sort.Strings(names)
+	for _, headerName := range names {
+		values := headers[headerName]
+		for _, value := range values {
+			if value = strings.TrimSpace(value); value != "" {
+				return value
+			}
+		}
+	}
+	return ""
+}

--- a/internal/app/opencode_compat_test.go
+++ b/internal/app/opencode_compat_test.go
@@ -1,0 +1,214 @@
+package app
+
+import (
+	"context"
+	"net/http"
+	"regexp"
+	"testing"
+	"time"
+
+	"ccLoad/internal/model"
+	"ccLoad/internal/protocol"
+	"ccLoad/internal/testutil"
+)
+
+func TestOpenCodeSessionHeaderUsesStableInputOrExecutionIdentity(t *testing.T) {
+	dst := http.Header{}
+	src := http.Header{"X-Session-Id": {"stable-session"}}
+	ensureOpenCodeSessionHeader(dst, src, "execution-fallback")
+	if got := dst.Get(opencodeSessionHeader); got != "stable-session" {
+		t.Fatalf("session header=%q, want stable-session", got)
+	}
+
+	dst = http.Header{}
+	ensureOpenCodeSessionHeader(dst, nil, "execution-fallback")
+	if got := dst.Get(opencodeSessionHeader); got != "execution-fallback" {
+		t.Fatalf("session header=%q, want execution fallback", got)
+	}
+
+	dst = http.Header{opencodeSessionHeader: {"explicit"}}
+	ensureOpenCodeSessionHeader(dst, nil, "other-session")
+	if got := dst.Get(opencodeSessionHeader); got != "explicit" {
+		t.Fatalf("explicit session header=%q, want explicit", got)
+	}
+}
+
+func TestOpenCodeSessionHeaderUsesDeterministicKnownHeaderFallback(t *testing.T) {
+	src := http.Header{
+		"X-Zeta-Session-Id":   {"zeta"},
+		"X-Alpha-Session-Id":  {"alpha"},
+		"X-Parent-Session-Id": {"parent"},
+	}
+	dst := http.Header{}
+	ensureOpenCodeSessionHeader(dst, src, "execution-fallback")
+	if got := dst.Get(opencodeSessionHeader); got != "alpha" {
+		t.Fatalf("session header=%q, want alphabetically first session id", got)
+	}
+}
+
+func TestOpenCodeChannelRecognizesOfficialGoEndpoint(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *model.Config
+		want bool
+	}{
+		{
+			name: "base endpoint",
+			cfg: &model.Config{
+				Name: "unrelated channel name",
+				URLs: model.ChannelURLs{{URL: "https://opencode.ai/zen/go"}},
+			},
+			want: true,
+		},
+		{
+			name: "responses endpoint",
+			cfg: &model.Config{
+				Name: "unrelated channel name",
+				URLs: model.ChannelURLs{{URL: "https://opencode.ai/zen/go/v1/responses"}},
+			},
+			want: true,
+		},
+		{
+			name: "exact URL marker",
+			cfg: &model.Config{
+				Name: "unrelated channel name",
+				URLs: model.ChannelURLs{{URL: "https://opencode.ai/zen/go#"}},
+			},
+			want: true,
+		},
+		{
+			name: "name without endpoint",
+			cfg:  &model.Config{Name: "OpenCode Go"},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isOpenCodeChannel(tt.cfg); got != tt.want {
+				t.Fatalf("isOpenCodeChannel()=%v, want %v for %+v", got, tt.want, tt.cfg)
+			}
+		})
+	}
+}
+
+func TestOpenCodeChannelRejectsLookalikeEndpoints(t *testing.T) {
+	for _, endpoint := range []string{
+		"https://opencode.ai.evil.example/zen/go",
+		"https://proxy-opencode.ai/zen/go",
+		"https://opencode.ai:8443/zen/go",
+		"http://opencode.ai/zen/go",
+		"https://opencode.ai/zen/gopher",
+		"https://opencode.ai/zen/go-extra",
+		"https://opencode.ai/other/zen/go",
+		"https://opencode.ai/zen%2Fgo",
+		"https://opencode.ai/zen/go/../other",
+	} {
+		t.Run(endpoint, func(t *testing.T) {
+			cfg := &model.Config{
+				Name: "OpenCode Go",
+				URLs: model.ChannelURLs{{URL: endpoint}},
+			}
+			if isOpenCodeChannel(cfg) {
+				t.Fatalf("lookalike endpoint was recognized: %q", endpoint)
+			}
+		})
+	}
+}
+
+func TestOpenCodeSessionHeaderIsStableForRepeatedBuilders(t *testing.T) {
+	src := http.Header{
+		"X-Session-Id":       {"native-session"},
+		"X-OpenCode-Session": {"explicit-session"},
+	}
+	first := http.Header{}
+	second := http.Header{}
+	ensureOpenCodeSessionHeader(first, src, "execution-session")
+	ensureOpenCodeSessionHeader(second, src, "execution-session")
+	if got := first.Get(opencodeSessionHeader); got != "explicit-session" {
+		t.Fatalf("explicit source header=%q, want explicit-session", got)
+	}
+	if got := second.Get(opencodeSessionHeader); got != first.Get(opencodeSessionHeader) {
+		t.Fatalf("same session was not stable: first=%q second=%q", first.Get(opencodeSessionHeader), got)
+	}
+
+	dst := http.Header{
+		"X-OpenCode-Session": {"destination-explicit"},
+		"X-Session-Id":       {"destination-native"},
+	}
+	ensureOpenCodeSessionHeader(dst, src, "other-session")
+	if got := dst.Get(opencodeSessionHeader); got != "destination-explicit" {
+		t.Fatalf("explicit destination header=%q, want destination-explicit", got)
+	}
+}
+
+func TestOpenCodeSessionHeaderFallsBackToUUID(t *testing.T) {
+	dst := http.Header{}
+	ensureOpenCodeSessionHeader(dst, nil, "")
+	got := dst.Get(opencodeSessionHeader)
+	if !regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`).MatchString(got) {
+		t.Fatalf("session header=%q is not a UUIDv4", got)
+	}
+}
+
+func TestOpenCodeSessionHeaderIsUsedByProxyAndAdminBuilders(t *testing.T) {
+	const endpoint = "https://opencode.ai/zen/go"
+	cfg := &model.Config{
+		ID:   4,
+		Name: "OpenCode Go",
+		URLs: model.ChannelURLs{{URL: endpoint}},
+	}
+
+	srv := newInMemoryServer(t)
+	body := []byte(`{"model":"gpt-5.4","input":[]}`)
+	proxyCtx := &requestContext{
+		ctx:              context.Background(),
+		startTime:        time.Now(),
+		clientProtocol:   protocol.OpenAI,
+		upstreamProtocol: protocol.Codex,
+		transformPlan: protocol.TransformPlan{
+			ClientProtocol:   protocol.OpenAI,
+			UpstreamProtocol: protocol.Codex,
+			RequestFamily:    protocol.RequestFamilyResponses,
+			OriginalBody:     body,
+			TranslatedBody:   body,
+			OriginalModel:    "gpt-5.4",
+			ActualModel:      "gpt-5.4",
+		},
+	}
+	proxyReq, err := srv.buildProxyRequest(
+		proxyCtx,
+		cfg,
+		"sk-test-key",
+		http.MethodPost,
+		body,
+		http.Header{"X-Session-Id": {"proxy-session"}},
+		"",
+		"/v1/responses",
+		endpoint,
+	)
+	if err != nil {
+		t.Fatalf("buildProxyRequest failed: %v", err)
+	}
+	if got := proxyReq.Header.Get(opencodeSessionHeader); got != "proxy-session" {
+		t.Fatalf("proxy OpenCode session=%q, want proxy-session", got)
+	}
+
+	adminTestReq := &testutil.TestChannelRequest{
+		Model:          "gpt-5.4",
+		ClientProtocol: "openai",
+		SessionID:      "admin-session",
+	}
+	adminReq, _, cancel, err := srv.buildTestUpstreamRequestForProtocol(
+		context.Background(), cfg, "sk-test-key", adminTestReq,
+		adminTestReq.Model, "openai", "codex", endpoint,
+	)
+	if cancel != nil {
+		defer cancel()
+	}
+	if err != nil {
+		t.Fatalf("buildTestUpstreamRequestForProtocol failed: %v", err)
+	}
+	if got, want := adminReq.Header.Get(opencodeSessionHeader), adminTestReq.ResolveSessionID(); got != want {
+		t.Fatalf("admin OpenCode session=%q, want resolved session %q", got, want)
+	}
+}

--- a/internal/app/proxy_forward.go
+++ b/internal/app/proxy_forward.go
@@ -366,7 +366,13 @@ func (s *Server) buildProxyRequest(
 		isAnyrouterChannel(cfg) {
 		injectAnthropicBetaFlag(req, "context-1m-2025-08-07")
 	}
-
+	if isOpenCodeChannel(cfg) {
+		executionIdentity := ""
+		if reqCtx != nil {
+			executionIdentity = reqCtx.executionIdentity
+		}
+		ensureOpenCodeSessionHeader(req.Header, hdr, executionIdentity)
+	}
 	// 7. 非 Anthropic 上游：移除 Anthropic 协议专属头（anthropic-version/anthropic-beta 等）
 	stripAnthropicProtocolHeaders(req, runtimeUpstreamProtocol(reqCtx, cfg))
 
@@ -704,11 +710,36 @@ func buildStreamDiagnostics(streamErr error, readStats *streamReadStats, streamC
 		if streamComplete {
 			return "" // 不触发冷却，数据已完整
 		}
-		return fmt.Sprintf("[WARN] 流传输中断: 错误=%v | 已读取=%d字节(分%d次) | 流结束标志=%v | 渠道=%s | Content-Type=%s",
-			streamErr, bytesRead, readCount, streamComplete, upstreamProtocol, contentType)
+		return fmt.Sprintf("[WARN] 流传输中断: 错误=%v | 已读取=%d字节(分%d次) | 流结束标志=%v | 渠道=%s | Content-Type=%s | %s",
+			streamErr, bytesRead, readCount, streamComplete, upstreamProtocol, contentType,
+			streamTimingDiagnostics(readStats))
 	}
 
 	return ""
+}
+
+// annotateStreamDisconnectError keeps context cancellation discoverable by
+// errors.Is while making the transport direction and timing visible in the
+// ordinary 499 error log. It deliberately does not populate StreamDiagMsg,
+// which is reserved for upstream stream failures and drives cooldown.
+func annotateStreamDisconnectError(streamErr error, readStats *streamReadStats) error {
+	if streamErr == nil || readStats == nil || !isClientDisconnectError(streamErr) {
+		return streamErr
+	}
+	return fmt.Errorf("%w (%s)", streamErr, streamTimingDiagnostics(readStats))
+}
+
+func streamTimingDiagnostics(readStats *streamReadStats) string {
+	if readStats == nil {
+		return "流时序: 上游最后读取=未知 | 下游最后写入=未知 | 下游最后Flush=未知 | 下游已写=0字节"
+	}
+	return fmt.Sprintf(
+		"流时序: 上游最后读取=%.3fs | 下游最后写入=%.3fs(次数%d) | 下游最后Flush=%.3fs(次数%d) | 下游已写=%d字节",
+		readStats.lastReadSec,
+		readStats.lastWriteSec, readStats.downstreamWrites,
+		readStats.lastFlushSec, readStats.downstreamFlushes,
+		readStats.downstreamBytes,
+	)
 }
 
 func translatedStreamChunksComplete(clientProtocol protocol.Protocol, chunks [][]byte) bool {
@@ -1044,6 +1075,15 @@ func (s *Server) handleSuccessResponse(
 	readStats *streamReadStats,
 	observer *ForwardObserver,
 ) (*fwResult, float64, error) {
+	if reqCtx != nil && reqCtx.isStreaming {
+		w = wrapStreamResponseWriter(w, readStats, reqCtx.startTime)
+	}
+	finishStreaming := func(result *fwResult, duration float64, streamErr error) (*fwResult, float64, error) {
+		if reqCtx != nil && reqCtx.isStreaming {
+			streamErr = annotateStreamDisconnectError(streamErr, readStats)
+		}
+		return result, duration, streamErr
+	}
 	// The framing repair is a Codex Responses compatibility fix. Do not put a
 	// generic decorator on every SSE response: Anthropic/OpenAI SSE must remain
 	// byte-for-byte passthrough, and probing an arbitrary stream can block before
@@ -1069,7 +1109,7 @@ func (s *Server) handleSuccessResponse(
 		return s.handleResponsesSSENonStreamSuccessResponse(reqCtx, resp, hdrClone, w, readStats)
 	}
 	if reqCtx.transformPlan.Streaming && isXAIImagesResponsesPlan(reqCtx.transformPlan) {
-		return s.handleXAIImagesResponsesStreamSuccessResponse(reqCtx, resp, hdrClone, w, readStats, observer)
+		return finishStreaming(s.handleXAIImagesResponsesStreamSuccessResponse(reqCtx, resp, hdrClone, w, readStats, observer))
 	}
 	if reqCtx.isStreaming && s.protocolRegistry != nil {
 		detectedProtocol, transform, err := maybePrepareDynamicStreamTransform(reqCtx, resp)
@@ -1083,16 +1123,16 @@ func (s *Server) handleSuccessResponse(
 			isSSE = true
 		}
 		if err != nil {
-			return &fwResult{
+			return finishStreaming(&fwResult{
 				Status:         resp.StatusCode,
 				UpstreamStatus: resp.StatusCode,
 				Header:         hdrClone,
 				FirstByteTime:  responseFirstByteSec(reqCtx, readStats),
 				BytesReceived:  readStats.totalBytes,
-			}, reqCtx.Duration().Seconds(), err
+			}, reqCtx.Duration().Seconds(), err)
 		}
 		if transform {
-			return s.handleTranslatedStreamSuccessResponse(reqCtx, resp, hdrClone, w, string(detectedProtocol), readStats, observer)
+			return finishStreaming(s.handleTranslatedStreamSuccessResponse(reqCtx, resp, hdrClone, w, string(detectedProtocol), readStats, observer))
 		}
 	}
 
@@ -1120,7 +1160,7 @@ func (s *Server) handleSuccessResponse(
 		(reqCtx.transformPlan.NeedsTransform || reqCtx.antigravityOAuth || reqCtx.codexMultiAgentV2Optimized) &&
 		(strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream") ||
 			strings.Contains(resp.Header.Get("Content-Type"), "text/plain")) {
-		return s.handleTranslatedStreamSuccessResponse(reqCtx, resp, hdrClone, w, upstreamProtocol, readStats, observer)
+		return finishStreaming(s.handleTranslatedStreamSuccessResponse(reqCtx, resp, hdrClone, w, upstreamProtocol, readStats, observer))
 	}
 
 	if !reqCtx.isStreaming &&
@@ -1232,7 +1272,7 @@ func (s *Server) handleSuccessResponse(
 		}
 	}
 
-	return result, reqCtx.Duration().Seconds(), streamErr
+	return finishStreaming(result, reqCtx.Duration().Seconds(), streamErr)
 }
 
 func (s *Server) handleTranslatedNonStreamSuccessResponse(
@@ -1592,6 +1632,12 @@ func attachFirstByteDetector(
 	resp.Body = &firstByteDetector{
 		ReadCloser: resp.Body,
 		stats:      readStats,
+		requestStart: func() time.Time {
+			if reqCtx == nil {
+				return time.Time{}
+			}
+			return reqCtx.startTime
+		}(),
 		onFirstRead: func() {
 			if reqCtx.isStreaming && resp.StatusCode >= 200 && resp.StatusCode < 300 {
 				return
@@ -2903,6 +2949,18 @@ func isInvalidEncryptedContentError(body []byte) bool {
 			strings.Contains(message, "could not decode")) {
 		return true
 	}
+	// Packy uses the Responses error shape with a provider-specific
+	// `invalid-argument` code and keeps the field name's underscore in its
+	// message: "Could not decrypt the provided encrypted_content. Ensure the
+	// value is the unmodified encrypted_content from a previous response.".
+	// Keep the surrounding provenance wording in the predicate so an unrelated
+	// decryption failure does not trigger a replay that drops conversation state.
+	if strings.Contains(message, "encrypted_content") &&
+		strings.Contains(message, "could not decrypt") &&
+		(strings.Contains(message, "unmodified encrypted_content") ||
+			strings.Contains(message, "previous response")) {
+		return true
+	}
 	return strings.Contains(message, "compaction blob") &&
 		(strings.Contains(message, "could not decode") || strings.Contains(message, "unmodified from the compact response"))
 }
@@ -3048,8 +3106,31 @@ func isUnsupportedThinkingError(body []byte) bool {
 }
 
 func codexBodyWithoutEncryptedInputItems(body []byte) ([]byte, bool) {
+	input := gjson.GetBytes(body, "input")
+	if !input.IsArray() {
+		return nil, false
+	}
+	// Only encrypted reasoning is provider-private retry metadata. Keep
+	// compaction and tool call/output items so the replay retains its history.
+	removed := false
+	retainedHistory := false
+	for _, item := range input.Array() {
+		if item.IsObject() &&
+			item.Get("type").Type == gjson.String &&
+			item.Get("type").String() == "reasoning" &&
+			item.Get("encrypted_content").Exists() {
+			removed = true
+			continue
+		}
+		retainedHistory = true
+	}
+	if !removed || !retainedHistory {
+		return nil, false
+	}
 	return deleteCodexInputItems(body, func(item gjson.Result) bool {
-		return (item.Get("type").Type == gjson.String && item.Get("type").String() == "reasoning") || item.Get("encrypted_content").Exists()
+		return item.Get("type").Type == gjson.String &&
+			item.Get("type").String() == "reasoning" &&
+			item.Get("encrypted_content").Exists()
 	})
 }
 
@@ -3263,6 +3344,13 @@ func collectJSONKeyPaths(value gjson.Result, prefix, key string, depth int, path
 		return
 	}
 	if value.IsObject() {
+		// Compaction payloads carry opaque conversation history. Keep the entire
+		// subtree intact when stripping optional encrypted content elsewhere.
+		typ := value.Get("type")
+		if typ.Type == gjson.String &&
+			(typ.String() == "compaction" || typ.String() == "compaction_summary") {
+			return
+		}
 		value.ForEach(func(name, child gjson.Result) bool {
 			childPath := sjsonObjectPathJoin(prefix, name.String())
 			if name.String() == key {

--- a/internal/app/proxy_forward_test.go
+++ b/internal/app/proxy_forward_test.go
@@ -1069,6 +1069,167 @@ func TestCodexBodyWithoutThinking_RemovesReasoningControls(t *testing.T) {
 	assertFieldOrder(t, text, `"model"`, `"include"`, `"input"`)
 }
 
+func TestIsInvalidEncryptedContentErrorRecognizesPackyMessage(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			name: "Packy invalid argument",
+			body: `{"error":{"message":"Could not decrypt the provided encrypted_content. Ensure the value is the unmodified encrypted_content from a previous response.","type":"packy_invalid-argument","code":"invalid-argument"}}`,
+			want: true,
+		},
+		{
+			name: "legacy Codex response",
+			body: `{"error":{"message":"The encrypted content could not be verified. Reason: Encrypted content could not be decrypted or parsed.","type":"invalid_request_error","param":"","code":"invalid_encrypted_content"}}`,
+			want: true,
+		},
+		{
+			name: "generic decryption failure",
+			body: `{"error":{"message":"Could not decrypt the provided request token."}}`,
+			want: false,
+		},
+		{
+			name: "encrypted content without replay provenance",
+			body: `{"error":{"message":"Could not decrypt encrypted_content."}}`,
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isInvalidEncryptedContentError([]byte(tc.body)); got != tc.want {
+				t.Fatalf("isInvalidEncryptedContentError()=%v, want %v for %s", got, tc.want, tc.body)
+			}
+		})
+	}
+}
+
+func TestCodexBodyWithoutEncryptedInputItemsPreservesCompactionAndToolHistory(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"model":"gpt-5.5","input":[
+		{"type":"compaction","encrypted_content":"opaque-summary"},
+		{"type":"reasoning","summary":[],"encrypted_content":"opaque-reasoning"},
+		{"type":"message","role":"user","content":[{"type":"input_text","text":"continue"}]},
+		{"type":"function_call","call_id":"call-1","name":"lookup","arguments":"{}"},
+		{"type":"function_call_output","call_id":"call-1","output":"ok"}
+	]}`)
+
+	got, ok := codexBodyWithoutEncryptedInputItems(body)
+	if !ok {
+		t.Fatal("codexBodyWithoutEncryptedInputItems returned ok=false")
+	}
+	items := gjson.GetBytes(got, "input").Array()
+	if len(items) != 4 {
+		t.Fatalf("retry input items=%d, want 4: %s", len(items), got)
+	}
+	if compaction := gjson.GetBytes(got, "input.0"); compaction.Get("type").String() != "compaction" ||
+		compaction.Get("encrypted_content").String() != "opaque-summary" {
+		t.Fatalf("encrypted compaction was changed or removed: %s", got)
+	}
+	if gjson.GetBytes(got, "input.#(type==reasoning)").Exists() {
+		t.Fatalf("encrypted reasoning should be removed: %s", got)
+	}
+	for index, wantType := range []string{"message", "function_call", "function_call_output"} {
+		if gotType := gjson.GetBytes(got, fmt.Sprintf("input.%d.type", index+1)).String(); gotType != wantType {
+			t.Fatalf("input.%d.type=%q, want %q: %s", index+1, gotType, wantType, got)
+		}
+	}
+	if gotCallID := gjson.GetBytes(got, "input.3.call_id").String(); gotCallID != "call-1" {
+		t.Fatalf("tool output call_id=%q, want call-1: %s", gotCallID, got)
+	}
+}
+
+func TestCodexBodyWithoutEncryptedInputItemsOnlyRemovesEncryptedReasoning(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"model":"gpt-5.5","input":[
+		{"type":"reasoning","summary":[{"type":"summary_text","text":"clear reasoning"}]},
+		{"type":"message","role":"user","content":[{"type":"input_text","text":"continue"}]}
+	]}`)
+
+	if got, ok := codexBodyWithoutEncryptedInputItems(body); ok || got != nil {
+		t.Fatalf("plain reasoning must not be stripped by encrypted-content retry: ok=%v body=%s", ok, got)
+	}
+}
+
+func TestCodexBodyWithoutEncryptedContentPreservesCompaction(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"model":"gpt-5.5","input":[
+		{"type":"compaction","encrypted_content":"opaque-summary"},
+		{"type":"compaction_summary","encrypted_content":"opaque-summary-2"},
+		{"type":"reasoning","encrypted_content":"opaque-reasoning"},
+		{"type":"message","role":"user","content":"continue"}
+	]}`)
+
+	got, ok := codexBodyWithoutEncryptedContent(body)
+	if !ok {
+		t.Fatal("codexBodyWithoutEncryptedContent returned ok=false")
+	}
+	if gjson.GetBytes(got, "input.0.type").String() != "compaction" ||
+		gjson.GetBytes(got, "input.0.encrypted_content").String() != "opaque-summary" {
+		t.Fatalf("encrypted compaction was changed or removed: %s", got)
+	}
+	if gjson.GetBytes(got, "input.1.type").String() != "compaction_summary" ||
+		gjson.GetBytes(got, "input.1.encrypted_content").String() != "opaque-summary-2" {
+		t.Fatalf("encrypted compaction summary was changed or removed: %s", got)
+	}
+	if gjson.GetBytes(got, "input.2.encrypted_content").Exists() {
+		t.Fatalf("reasoning encrypted_content should be removed: %s", got)
+	}
+}
+
+func TestCodexBodyWithoutEncryptedContentPreservesLargeValuesAndDottedKeys(t *testing.T) {
+	body := []byte(`{"input":[{"type":"compaction","encrypted_content":"keep","metadata":{"turn.id":9007199254740993123456789}},{"type":"tool_result","payload":{"encrypted_content":"drop","turn.id":9007199254740993123456789}}]}`)
+
+	got, ok := codexBodyWithoutEncryptedContent(body)
+	if !ok {
+		t.Fatal("codexBodyWithoutEncryptedContent returned ok=false")
+	}
+	if !bytes.Contains(got, []byte(`"turn.id":9007199254740993123456789`)) {
+		t.Fatalf("large dotted-key value was changed: %s", got)
+	}
+	if !bytes.Contains(got, []byte(`"type":"compaction","encrypted_content":"keep"`)) {
+		t.Fatalf("compaction payload was changed: %s", got)
+	}
+	if bytes.Contains(got, []byte(`"encrypted_content":"drop"`)) {
+		t.Fatalf("non-compaction encrypted content was retained: %s", got)
+	}
+}
+
+func TestCodexRetryBodyFor400_RecognizesPackyEncryptedContentError(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"model":"gpt-5.5","input":[
+		{"type":"reasoning","summary":[],"encrypted_content":"opaque-reasoning"},
+		{"type":"message","role":"user","content":[{"type":"input_text","text":"continue"}]}
+	]}`)
+	res := &fwResult{
+		Status: http.StatusBadRequest,
+		Body:   []byte(`{"error":{"message":"Could not decrypt the provided encrypted_content. Ensure the value is the unmodified encrypted_content from a previous response.","type":"packy_invalid-argument","code":"invalid-argument"}}`),
+	}
+	plan := protocol.TransformPlan{TranslatedBody: body}
+
+	got, strategy, ok := codexRetryBodyFor400(protocol.Codex, nil, plan, res)
+	if !ok {
+		t.Fatal("codexRetryBodyFor400 returned ok=false for Packy error")
+	}
+	if strategy != "strip_codex_encrypted_input" {
+		t.Fatalf("strategy=%q, want strip_codex_encrypted_input", strategy)
+	}
+	if gjson.GetBytes(got, "input.#").Int() != 1 ||
+		gjson.GetBytes(got, "input.0.type").String() != "message" ||
+		gjson.GetBytes(got, "input.0.content.0.text").String() != "continue" {
+		t.Fatalf("retry body did not retain usable message history: %s", got)
+	}
+}
+
 func TestResponsesRetryBodyForMissingRequiredParameter_DropsInputItem(t *testing.T) {
 	t.Parallel()
 	body := []byte(`{
@@ -1779,7 +1940,7 @@ func TestCodexRetryBodyFor400_UsesSSEErrorStatusForEncryptedContent(t *testing.T
 	body := []byte(`{
 		"model":"gpt-5.5",
 		"input":[
-			{"type":"compaction","encrypted_content":"drop-compaction"},
+			{"type":"compaction","encrypted_content":"keep-compaction"},
 			{"type":"reasoning","summary":[],"encrypted_content":"drop-reasoning"},
 			{"type":"message","role":"user","content":[{"type":"input_text","text":"keep"}]}
 		]
@@ -1797,8 +1958,11 @@ func TestCodexRetryBodyFor400_UsesSSEErrorStatusForEncryptedContent(t *testing.T
 	if strategy != "strip_codex_encrypted_input" {
 		t.Fatalf("strategy=%q, want strip_codex_encrypted_input", strategy)
 	}
-	if items := gjson.GetBytes(got, "input").Array(); len(items) != 1 || items[0].Get("type").String() != "message" {
-		t.Fatalf("retry body should keep only the non-encrypted message, got %s", got)
+	if items := gjson.GetBytes(got, "input").Array(); len(items) != 2 ||
+		items[0].Get("type").String() != "compaction" ||
+		items[0].Get("encrypted_content").String() != "keep-compaction" ||
+		items[1].Get("type").String() != "message" {
+		t.Fatalf("retry body should preserve compaction and keep the message, got %s", got)
 	}
 }
 

--- a/internal/app/proxy_integration_test.go
+++ b/internal/app/proxy_integration_test.go
@@ -8277,7 +8277,7 @@ func TestProxy_Success_NonStreaming_OpenAIToCodexTransform(t *testing.T) {
 func TestProxy_CodexInvalidEncryptedContentRetriesWithoutEncryptedInputItems(t *testing.T) {
 	t.Parallel()
 
-	const invalidEncryptedContentBody = `{"error":{"message":"The encrypted content could not be verified. Reason: Encrypted content could not be decrypted or parsed.","type":"invalid_request_error","param":"","code":"invalid_encrypted_content"}}`
+	const invalidEncryptedContentBody = `{"error":{"message":"Could not decrypt the provided encrypted_content. Ensure the value is the unmodified encrypted_content from a previous response.","type":"packy_invalid-argument","code":"invalid-argument"}}`
 
 	var attempts atomic.Int32
 	var bodies [][]byte
@@ -8310,7 +8310,7 @@ func TestProxy_CodexInvalidEncryptedContentRetriesWithoutEncryptedInputItems(t *
 	w := doProxyRequest(t, env.engine, "/v1/responses", map[string]any{
 		"model": "gpt-5.5",
 		"input": []map[string]any{
-			{"type": "compaction", "encrypted_content": "drop-compaction"},
+			{"type": "compaction", "encrypted_content": "keep-compaction"},
 			{"type": "reasoning", "summary": []any{}, "content": nil, "encrypted_content": "drop-reasoning"},
 			{"type": "message", "role": "user", "content": []map[string]any{{"type": "input_text", "text": "hi"}}},
 		},
@@ -8331,9 +8331,10 @@ func TestProxy_CodexInvalidEncryptedContentRetriesWithoutEncryptedInputItems(t *
 	if bytes.Contains(bodies[1], []byte(`"type":"reasoning"`)) {
 		t.Fatalf("retry request should remove reasoning item, got %s", bodies[1])
 	}
-	if bytes.Contains(bodies[1], []byte(`"encrypted_content"`)) ||
-		bytes.Contains(bodies[1], []byte(`"type":"compaction"`)) {
-		t.Fatalf("retry request should remove encrypted input items, got %s", bodies[1])
+	if bytes.Contains(bodies[1], []byte(`"type":"reasoning"`)) ||
+		!bytes.Contains(bodies[1], []byte(`"type":"compaction"`)) ||
+		!bytes.Contains(bodies[1], []byte(`"encrypted_content":"keep-compaction"`)) {
+		t.Fatalf("retry request should remove encrypted reasoning while preserving compaction, got %s", bodies[1])
 	}
 	if !bytes.Contains(bodies[1], []byte(`"type":"message"`)) {
 		t.Fatalf("retry request should keep non-encrypted input items, got %s", bodies[1])

--- a/internal/app/proxy_responses_websocket_test.go
+++ b/internal/app/proxy_responses_websocket_test.go
@@ -5483,12 +5483,16 @@ func TestNativeCodexWebsocketInvalidEncryptedContentReconnectsWithStrippedReplay
 	if !bytes.Contains(first, []byte(`"encrypted_content"`)) {
 		t.Fatalf("first upstream request dropped encrypted content too early: %s", first)
 	}
-	if bytes.Contains(replay, []byte(`"encrypted_content"`)) {
-		t.Fatalf("replay retained rejected encrypted content: %s", replay)
-	}
 	items := gjson.GetBytes(replay, "input").Array()
-	if len(items) != 1 || items[0].Get("type").String() != "message" || handshakes.Load() != 2 {
-		t.Fatalf("replay input=%s handshakes=%d, want only the message and two handshakes", replay, handshakes.Load())
+	if len(items) != 2 || items[0].Get("type").String() != "compaction" ||
+		items[1].Get("type").String() != "message" || handshakes.Load() != 2 {
+		t.Fatalf("replay input=%s handshakes=%d, want compaction, message and two handshakes", gjson.GetBytes(replay, "input").Raw, handshakes.Load())
+	}
+	if items[0].Raw != gjson.GetBytes(first, "input.1").Raw {
+		t.Fatalf("replay changed the compaction history: %s", items[0].Raw)
+	}
+	if items[1].Get("content").String() != "keep going" {
+		t.Fatalf("replay changed the retained message: %s", items[1].Raw)
 	}
 }
 

--- a/internal/app/proxy_stream.go
+++ b/internal/app/proxy_stream.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 )
 
 const maxSSEEventBytes = 50 * 1024 * 1024
@@ -39,14 +40,21 @@ type streamReadStats struct {
 	totalBytes         int64
 	firstByteSec       float64 // 上游首个有效事件耗时（秒），用于首字超时控制
 	clientFirstByteSec float64 // 首个客户端可见事件耗时（秒），用于实时状态和日志
+	lastReadSec        float64 // 从本次请求开始到上游最近一次读取数据的耗时（秒）
+	lastWriteSec       float64 // 从本次请求开始到下游最近一次写入数据的耗时（秒）
+	lastFlushSec       float64 // 从本次请求开始到下游最近一次Flush的耗时（秒）
+	downstreamBytes    int64   // 实际写入下游的字节数（不含仅缓冲在网关内的数据）
+	downstreamWrites   int     // 下游实际写入调用次数（用于区分未写出与零字节响应）
+	downstreamFlushes  int     // 下游实际Flush调用次数
 }
 
 // firstByteDetector 检测首字节读取时间和传输统计的Reader包装器
 type firstByteDetector struct {
 	io.ReadCloser
-	stats       *streamReadStats
-	onFirstRead func()
-	onBytesRead func(int64) // 可选：每次读取后的回调（nil 时不触发）
+	stats        *streamReadStats
+	requestStart time.Time
+	onFirstRead  func()
+	onBytesRead  func(int64) // 可选：每次读取后的回调（nil 时不触发）
 }
 
 // Read 实现io.Reader接口，记录读取统计
@@ -57,6 +65,7 @@ func (r *firstByteDetector) Read(p []byte) (n int, err error) {
 		if r.stats != nil {
 			r.stats.readCount++
 			r.stats.totalBytes += int64(n)
+			r.stats.lastReadSec = streamElapsedSeconds(r.requestStart)
 		}
 		// 触发首次读取回调
 		if r.onFirstRead != nil {
@@ -69,6 +78,71 @@ func (r *firstByteDetector) Read(p []byte) (n int, err error) {
 		}
 	}
 	return
+}
+
+// streamResponseWriter 记录实际写到客户端的流量及时间。
+// 它只包裹流式响应路径；数据仍由底层 ResponseWriter 原样写出，不缓存、不记录正文。
+type streamResponseWriter struct {
+	target       http.ResponseWriter
+	stats        *streamReadStats
+	requestStart time.Time
+}
+
+func newStreamResponseWriter(target http.ResponseWriter, stats *streamReadStats, requestStart time.Time) *streamResponseWriter {
+	return &streamResponseWriter{target: target, stats: stats, requestStart: requestStart}
+}
+
+func wrapStreamResponseWriter(target http.ResponseWriter, stats *streamReadStats, requestStart time.Time) http.ResponseWriter {
+	if target == nil {
+		return nil
+	}
+	if _, ok := target.(*streamResponseWriter); ok {
+		return target
+	}
+	return newStreamResponseWriter(target, stats, requestStart)
+}
+
+func (w *streamResponseWriter) Header() http.Header {
+	return w.target.Header()
+}
+
+func (w *streamResponseWriter) WriteHeader(statusCode int) {
+	w.target.WriteHeader(statusCode)
+}
+
+func (w *streamResponseWriter) Write(p []byte) (int, error) {
+	n, err := w.target.Write(p)
+	if w.stats != nil && n > 0 {
+		w.stats.downstreamWrites++
+		w.stats.downstreamBytes += int64(n)
+		w.stats.lastWriteSec = streamElapsedSeconds(w.requestStart)
+	}
+	return n, err
+}
+
+func (w *streamResponseWriter) Flush() {
+	flusher, ok := w.target.(http.Flusher)
+	if !ok {
+		return
+	}
+	flusher.Flush()
+	if w.stats != nil {
+		w.stats.downstreamFlushes++
+		w.stats.lastFlushSec = streamElapsedSeconds(w.requestStart)
+	}
+}
+
+// Unwrap lets http.ResponseController reach the original writer for deadlines
+// and other optional ResponseWriter capabilities.
+func (w *streamResponseWriter) Unwrap() http.ResponseWriter {
+	return w.target
+}
+
+func streamElapsedSeconds(requestStart time.Time) float64 {
+	if requestStart.IsZero() {
+		return 0
+	}
+	return positiveDuration(time.Since(requestStart)).Seconds()
 }
 
 // ============================================================================

--- a/internal/app/proxy_stream_test.go
+++ b/internal/app/proxy_stream_test.go
@@ -6,11 +6,15 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net/http"
 	"os"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"ccLoad/internal/protocol"
+	"ccLoad/internal/protocol/builtin"
 )
 
 func readCodexMalformedSSEFixture(t *testing.T) []byte {
@@ -236,6 +240,53 @@ type errorReader struct {
 	err error
 }
 
+type streamStatsResponseWriter struct {
+	header        http.Header
+	status        int
+	body          bytes.Buffer
+	writeCalls    int
+	flushCalls    int
+	writeErr      error
+	writeBytes    int
+	flushObserved chan struct{}
+}
+
+func (w *streamStatsResponseWriter) Header() http.Header {
+	if w.header == nil {
+		w.header = make(http.Header)
+	}
+	return w.header
+}
+
+func (w *streamStatsResponseWriter) WriteHeader(status int) {
+	if w.status == 0 {
+		w.status = status
+	}
+}
+
+func (w *streamStatsResponseWriter) Write(p []byte) (int, error) {
+	w.writeCalls++
+	if w.writeErr != nil {
+		n := w.writeBytes
+		if n > len(p) {
+			n = len(p)
+		}
+		return n, w.writeErr
+	}
+	return w.body.Write(p)
+}
+
+func (w *streamStatsResponseWriter) Flush() {
+	w.flushCalls++
+	if w.flushObserved != nil {
+		select {
+		case <-w.flushObserved:
+		default:
+			close(w.flushObserved)
+		}
+	}
+}
+
 type repeatedByteReader struct {
 	remaining int
 }
@@ -283,6 +334,164 @@ func (r *blockingReadCloser) Close() error {
 		close(r.closed)
 	})
 	return nil
+}
+
+func TestStreamResponseWriterTracksSuccessfulOutput(t *testing.T) {
+	start := time.Now().Add(-10 * time.Millisecond)
+	stats := &streamReadStats{}
+	target := &streamStatsResponseWriter{}
+	writer := newStreamResponseWriter(target, stats, start)
+
+	if n, err := writer.Write([]byte("hello")); err != nil || n != 5 {
+		t.Fatalf("Write() = (%d, %v), want (5, nil)", n, err)
+	}
+	writer.Flush()
+
+	if got, want := stats.downstreamBytes, int64(5); got != want {
+		t.Fatalf("downstreamBytes = %d, want %d", got, want)
+	}
+	if got, want := stats.downstreamWrites, 1; got != want {
+		t.Fatalf("downstreamWrites = %d, want %d", got, want)
+	}
+	if got, want := stats.downstreamFlushes, 1; got != want {
+		t.Fatalf("downstreamFlushes = %d, want %d", got, want)
+	}
+	if stats.lastWriteSec <= 0 || stats.lastFlushSec <= 0 {
+		t.Fatalf("output timings = write %.6f flush %.6f, want positive values", stats.lastWriteSec, stats.lastFlushSec)
+	}
+	if target.body.String() != "hello" {
+		t.Fatalf("forwarded body = %q, want %q", target.body.String(), "hello")
+	}
+}
+
+func TestStreamResponseWriterTracksPartialWriteWithError(t *testing.T) {
+	stats := &streamReadStats{}
+	target := &streamStatsResponseWriter{writeErr: io.ErrClosedPipe, writeBytes: 2}
+	writer := newStreamResponseWriter(target, stats, time.Now().Add(-10*time.Millisecond))
+
+	n, err := writer.Write([]byte("hello"))
+	if n != 2 || !errors.Is(err, io.ErrClosedPipe) {
+		t.Fatalf("Write() = (%d, %v), want (2, io.ErrClosedPipe)", n, err)
+	}
+	if stats.downstreamBytes != 2 || stats.downstreamWrites != 1 || stats.lastWriteSec <= 0 {
+		t.Fatalf("partial write stats = %#v, want n>0 to be recorded", *stats)
+	}
+}
+
+func TestDeferredResponseWriterTracksCommittedOutput(t *testing.T) {
+	start := time.Now().Add(-10 * time.Millisecond)
+	stats := &streamReadStats{}
+	target := &streamStatsResponseWriter{}
+	writer := newDeferredResponseWriter(newStreamResponseWriter(target, stats, start))
+
+	if _, err := writer.Write([]byte("buffered")); err != nil {
+		t.Fatalf("buffered Write() error = %v", err)
+	}
+	if stats.downstreamBytes != 0 || stats.downstreamWrites != 0 {
+		t.Fatalf("uncommitted output was counted: bytes=%d writes=%d", stats.downstreamBytes, stats.downstreamWrites)
+	}
+	if err := writer.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	if _, err := writer.Write([]byte("visible")); err != nil {
+		t.Fatalf("committed Write() error = %v", err)
+	}
+	writer.Flush()
+
+	if got, want := stats.downstreamBytes, int64(len("buffered")+len("visible")); got != want {
+		t.Fatalf("downstreamBytes = %d, want %d", got, want)
+	}
+	if got, want := stats.downstreamWrites, 2; got != want {
+		t.Fatalf("downstreamWrites = %d, want %d", got, want)
+	}
+	if got, want := stats.downstreamFlushes, 1; got != want {
+		t.Fatalf("downstreamFlushes = %d, want %d", got, want)
+	}
+	if target.body.String() != "bufferedvisible" {
+		t.Fatalf("forwarded body = %q, want %q", target.body.String(), "bufferedvisible")
+	}
+}
+
+func TestHandleSuccessResponseTracksRawStreamAndClientCancel(t *testing.T) {
+	const body = "data: {\"id\":\"c1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"}}]}\n\n"
+	reqCtx := &requestContext{
+		ctx:         context.Background(),
+		startTime:   time.Now().Add(-10 * time.Millisecond),
+		isStreaming: true,
+	}
+	readStats := &streamReadStats{}
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body: io.NopCloser(io.MultiReader(
+			strings.NewReader(body),
+			&errorReader{err: context.Canceled},
+		)),
+	}
+	attachFirstByteDetector(reqCtx, resp, readStats, nil)
+	target := &streamStatsResponseWriter{}
+	result, _, err := (&Server{}).handleSuccessResponse(
+		reqCtx, resp, resp.Header.Clone(), target, "openai", readStats, nil,
+	)
+	if err == nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("handleSuccessResponse() error = %v, want wrapped context.Canceled", err)
+	}
+	if result == nil || result.StreamDiagMsg != "" {
+		t.Fatalf("client cancellation should keep StreamDiagMsg empty, result=%#v", result)
+	}
+	if !strings.Contains(err.Error(), "流时序:") || !strings.Contains(err.Error(), "下游最后写入") {
+		t.Fatalf("client cancellation error lacks timing diagnostics: %v", err)
+	}
+	if readStats.lastReadSec <= 0 || readStats.downstreamBytes != int64(len(body)) ||
+		readStats.downstreamWrites == 0 || readStats.downstreamFlushes == 0 {
+		t.Fatalf("stream stats = %#v, want read/write/flush observations", *readStats)
+	}
+	if target.body.String() != body {
+		t.Fatalf("forwarded body = %q, want original SSE body", target.body.String())
+	}
+}
+
+func TestHandleSuccessResponseTracksTranslatedStream(t *testing.T) {
+	const body = "data: {\"id\":\"c1\",\"object\":\"chat.completion.chunk\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hello\"},\"finish_reason\":\"stop\"}]}\n\n"
+	start := time.Now().Add(-10 * time.Millisecond)
+	reqCtx := &requestContext{
+		ctx:         context.Background(),
+		startTime:   start,
+		isStreaming: true,
+		transformPlan: protocol.TransformPlan{
+			ClientProtocol:   protocol.Anthropic,
+			UpstreamProtocol: protocol.OpenAI,
+			OriginalModel:    "claude-3-5-sonnet",
+			ActualModel:      "gpt-4o",
+			NeedsTransform:   true,
+		},
+	}
+	readStats := &streamReadStats{}
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+	attachFirstByteDetector(reqCtx, resp, readStats, nil)
+	target := &streamStatsResponseWriter{}
+	registry := protocol.NewRegistry()
+	builtin.Register(registry)
+	result, _, err := (&Server{protocolRegistry: registry}).handleSuccessResponse(
+		reqCtx, resp, resp.Header.Clone(), target, "openai", readStats, nil,
+	)
+	if err != nil {
+		t.Fatalf("handleSuccessResponse() error = %v", err)
+	}
+	if result == nil || !result.ResponseCommitted {
+		t.Fatalf("translated stream result = %#v, want committed response", result)
+	}
+	if readStats.lastReadSec <= 0 || readStats.downstreamBytes == 0 ||
+		readStats.downstreamWrites == 0 || readStats.downstreamFlushes == 0 {
+		t.Fatalf("translated stream stats = %#v, want read/write/flush observations", *readStats)
+	}
+	if !strings.Contains(target.body.String(), "message_stop") {
+		t.Fatalf("translated response lacks message_stop: %s", target.body.String())
+	}
 }
 
 // TestStreamCopySSE_ContextCanceledDuringRead 测试在 Read 期间 context 被取消的场景

--- a/internal/app/proxy_tool_search_integration_test.go
+++ b/internal/app/proxy_tool_search_integration_test.go
@@ -1,0 +1,404 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"ccLoad/internal/model"
+
+	"github.com/tidwall/gjson"
+)
+
+const (
+	proxyToolSearchModel       = "tool-search-roundtrip"
+	proxyToolSearchLookupName  = "mcp__public__lookup"
+	proxyToolSearchLookupCall  = "call-lookup-1"
+	proxyToolSearchResultToken = "TOOL_SEARCH_RESULT_MARKER"
+)
+
+func TestProxy_CodexToolSearchRoundTripThroughOpenAI(t *testing.T) {
+	for _, streaming := range []bool{false, true} {
+		name := "non-stream"
+		if streaming {
+			name = "stream"
+		}
+		t.Run(name, func(t *testing.T) {
+			toolSearchRoundTripThroughOpenAI(t, streaming)
+		})
+	}
+}
+
+func toolSearchRoundTripThroughOpenAI(t *testing.T, streaming bool) {
+	t.Helper()
+
+	initialInput := proxyToolSearchInitialInput()
+	requestBody := map[string]any{
+		"model":  proxyToolSearchModel,
+		"stream": streaming,
+		"tools":  []any{proxyToolSearchDeclaration()},
+		"input":  initialInput,
+	}
+
+	var upstreamRequests [][]byte
+	var upstreamCalls atomic.Int32
+	env := setupProxyTestEnv(t, []testChannel{
+		{
+			name: "openai-tool-search", upstreamProtocol: "openai",
+			protocolTransformMode: model.ProtocolTransformModeLocal,
+			models:                proxyToolSearchModel, apiKey: "sk-tool-search",
+		},
+	}, map[int]string{0: "https://openai-tool-search.invalid"})
+	env.server.client = &http.Client{Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path != "/v1/chat/completions" {
+			return nil, fmt.Errorf("unexpected upstream path %s", r.URL.Path)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			return nil, err
+		}
+		upstreamRequests = append(upstreamRequests, body)
+		switch upstreamCalls.Add(1) {
+		case 1:
+			return proxyToolSearchChatResponse(streaming, true), nil
+		case 2:
+			return proxyToolSearchChatResponse(streaming, false), nil
+		default:
+			return nil, fmt.Errorf("unexpected upstream request %d", upstreamCalls.Load())
+		}
+	})}
+
+	firstResponse := doProxyRequest(t, env.engine, "/v1/responses", requestBody, nil)
+	if firstResponse.Code != http.StatusOK {
+		t.Fatalf("first request status=%d body=%s", firstResponse.Code, firstResponse.Body.String())
+	}
+	if got := upstreamCalls.Load(); got != 1 {
+		t.Fatalf("first request upstream calls=%d, want 1", got)
+	}
+
+	searchName := assertProxyToolSearchChatRequest(t, upstreamRequests[0], false, "")
+	assertProxyToolSearchClientFunctionCall(t, firstResponse.Body.Bytes(), streaming, proxyToolSearchLookupCall)
+
+	followupInput := append([]any{}, initialInput...)
+	followupInput = append(followupInput,
+		map[string]any{
+			"type":      "function_call",
+			"id":        "fc-lookup-1",
+			"status":    "completed",
+			"call_id":   proxyToolSearchLookupCall,
+			"name":      "lookup",
+			"namespace": "mcp__public",
+			"arguments": `{"query":"needle"}`,
+		},
+		map[string]any{
+			"type":    "function_call_output",
+			"call_id": proxyToolSearchLookupCall,
+			"output":  proxyToolSearchResultToken,
+		},
+		map[string]any{
+			"type": "message", "role": "user",
+			"content": []any{map[string]any{
+				"type": "input_text", "text": "Return the tool result marker exactly.",
+			}},
+		},
+	)
+	followupBody := map[string]any{
+		"model":  proxyToolSearchModel,
+		"stream": streaming,
+		"tools":  []any{proxyToolSearchDeclaration()},
+		"input":  followupInput,
+	}
+
+	secondResponse := doProxyRequest(t, env.engine, "/v1/responses", followupBody, nil)
+	if secondResponse.Code != http.StatusOK {
+		t.Fatalf("follow-up request status=%d body=%s", secondResponse.Code, secondResponse.Body.String())
+	}
+	if got := upstreamCalls.Load(); got != 2 {
+		t.Fatalf("follow-up upstream calls=%d, want 2", got)
+	}
+	assertProxyToolSearchChatRequest(t, upstreamRequests[1], true, searchName)
+	assertProxyToolSearchCompletedResponse(t, secondResponse.Body.Bytes(), streaming)
+}
+
+func proxyToolSearchInitialInput() []any {
+	return []any{
+		map[string]any{
+			"type": "message", "role": "user",
+			"content": []any{map[string]any{
+				"type": "input_text", "text": "Find the lookup tool, then use it.",
+			}},
+		},
+		map[string]any{
+			"type": "tool_search_call", "execution": "client", "call_id": "search-1",
+			"status": "completed", "arguments": map[string]any{"query": "lookup"},
+		},
+		map[string]any{
+			"type": "tool_search_output", "execution": "client", "call_id": "search-1",
+			"status": "completed", "tools": []any{proxyToolSearchLoadedNamespace()},
+		},
+		map[string]any{
+			"type": "message", "role": "user",
+			"content": []any{map[string]any{
+				"type": "input_text", "text": "Use lookup with query needle.",
+			}},
+		},
+	}
+}
+
+func proxyToolSearchDeclaration() map[string]any {
+	return map[string]any{
+		"type": "tool_search", "execution": "client", "description": "Load tools by query",
+		"parameters": map[string]any{
+			"type":       "object",
+			"properties": map[string]any{"query": map[string]any{"type": "string"}},
+			"required":   []string{"query"},
+		},
+	}
+}
+
+func proxyToolSearchLoadedNamespace() map[string]any {
+	return map[string]any{
+		"type": "namespace", "name": "mcp__public",
+		"tools": []any{map[string]any{
+			"type": "function", "name": "lookup", "description": "Look up a public record",
+			"parameters": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"query": map[string]any{"type": "string", "description": "Search query"},
+					"limit": map[string]any{"type": "integer", "minimum": 1},
+				},
+				"required":             []string{"query"},
+				"additionalProperties": false,
+			},
+		}},
+	}
+}
+
+func proxyToolSearchChatResponse(streaming, functionCall bool) *http.Response {
+	if functionCall {
+		if streaming {
+			body := strings.Join([]string{
+				`data: {"id":"chatcmpl-search-1","object":"chat.completion.chunk","created":1773896263,"model":"tool-search-roundtrip","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call-lookup-1","type":"function","function":{"name":"mcp__public__lookup","arguments":""}}]},"finish_reason":null}]}`,
+				`data: {"id":"chatcmpl-search-1","object":"chat.completion.chunk","created":1773896263,"model":"tool-search-roundtrip","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"query\":\"needle\"}"}}]},"finish_reason":"tool_calls"}]}`,
+				`data: [DONE]`,
+			}, "\n\n") + "\n\n"
+			return proxyToolSearchHTTPResponse("text/event-stream", []byte(body))
+		}
+		return proxyToolSearchHTTPResponse("application/json", []byte(`{"id":"chatcmpl-search-1","object":"chat.completion","created":1773896263,"model":"tool-search-roundtrip","choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[{"id":"call-lookup-1","type":"function","function":{"name":"mcp__public__lookup","arguments":"{\"query\":\"needle\"}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":10,"completion_tokens":2,"total_tokens":12}}`))
+	}
+
+	if streaming {
+		body := strings.Join([]string{
+			`data: {"id":"chatcmpl-search-2","object":"chat.completion.chunk","created":1773896264,"model":"tool-search-roundtrip","choices":[{"index":0,"delta":{"role":"assistant","content":"TOOL_SEARCH_RESULT_MARKER"},"finish_reason":null}]}`,
+			`data: {"id":"chatcmpl-search-2","object":"chat.completion.chunk","created":1773896264,"model":"tool-search-roundtrip","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+			`data: [DONE]`,
+		}, "\n\n") + "\n\n"
+		return proxyToolSearchHTTPResponse("text/event-stream", []byte(body))
+	}
+	return proxyToolSearchHTTPResponse("application/json", []byte(`{"id":"chatcmpl-search-2","object":"chat.completion","created":1773896264,"model":"tool-search-roundtrip","choices":[{"index":0,"message":{"role":"assistant","content":"TOOL_SEARCH_RESULT_MARKER"},"finish_reason":"stop"}],"usage":{"prompt_tokens":20,"completion_tokens":4,"total_tokens":24}}`))
+}
+
+func proxyToolSearchHTTPResponse(contentType string, body []byte) *http.Response {
+	return &http.Response{
+		StatusCode:    http.StatusOK,
+		Header:        http.Header{"Content-Type": []string{contentType}},
+		Body:          io.NopCloser(bytes.NewReader(body)),
+		ContentLength: int64(len(body)),
+	}
+}
+
+func assertProxyToolSearchChatRequest(t *testing.T, body []byte, followup bool, searchName string) string {
+	t.Helper()
+	var request map[string]any
+	if err := json.Unmarshal(body, &request); err != nil {
+		t.Fatalf("decode translated Chat request: %v body=%s", err, body)
+	}
+	if got := gjson.GetBytes(body, "messages.#").Int(); got < 4 {
+		t.Fatalf("translated Chat messages=%d, want at least 4: %s", got, body)
+	}
+	if got := gjson.GetBytes(body, "tools.#").Int(); got < 2 {
+		t.Fatalf("translated Chat tools=%d, want search plus loaded lookup: %s", got, body)
+	}
+
+	var foundSearchCall, foundSearchOutput, foundLookupCall, foundLookupOutput, foundFinalUser bool
+	searchCallIndex, searchOutputIndex := -1, -1
+	lookupCallIndex, lookupOutputIndex := -1, -1
+	searchInternalName := ""
+	for messageIndex, message := range gjson.GetBytes(body, "messages").Array() {
+		switch message.Get("role").String() {
+		case "assistant":
+			for _, toolCall := range message.Get("tool_calls").Array() {
+				callID := toolCall.Get("id").String()
+				name := toolCall.Get("function.name").String()
+				switch callID {
+				case "search-1":
+					foundSearchCall = true
+					searchCallIndex = messageIndex
+					searchInternalName = name
+					arguments := toolCall.Get("function.arguments")
+					if arguments.String() == "" || !strings.Contains(arguments.Raw, "lookup") {
+						t.Fatalf("search assistant tool call has empty arguments: %s", body)
+					}
+				case proxyToolSearchLookupCall:
+					foundLookupCall = true
+					lookupCallIndex = messageIndex
+					if name != proxyToolSearchLookupName {
+						t.Fatalf("lookup Chat function name=%q, want %q: %s", name, proxyToolSearchLookupName, body)
+					}
+				}
+			}
+		case "tool":
+			callID := message.Get("tool_call_id").String()
+			switch callID {
+			case "search-1":
+				foundSearchOutput = true
+				searchOutputIndex = messageIndex
+				content := message.Get("content")
+				if !strings.Contains(content.Raw, "mcp__public") || !strings.Contains(content.Raw, "lookup") {
+					t.Fatalf("search tool result did not preserve loaded lookup tool: %s", body)
+				}
+			case proxyToolSearchLookupCall:
+				foundLookupOutput = true
+				lookupOutputIndex = messageIndex
+				content := message.Get("content")
+				if content.String() != proxyToolSearchResultToken {
+					t.Fatalf("lookup tool result=%q, want marker %q: %s", content.String(), proxyToolSearchResultToken, body)
+				}
+			}
+		case "user":
+			if strings.Contains(message.Get("content.0.text").String(), "Return the tool result marker") {
+				foundFinalUser = true
+			}
+		}
+	}
+	if !foundSearchCall || !foundSearchOutput {
+		t.Fatalf("Chat request lost search assistant/tool pair: %s", body)
+	}
+	if searchOutputIndex != searchCallIndex+1 {
+		t.Fatalf("Chat search assistant/tool messages are not paired: call=%d output=%d body=%s", searchCallIndex, searchOutputIndex, body)
+	}
+	if followup && (!foundLookupCall || !foundLookupOutput || !foundFinalUser) {
+		t.Fatalf("follow-up Chat request lost lookup tool pair or final user message: %s", body)
+	}
+	if followup && lookupOutputIndex != lookupCallIndex+1 {
+		t.Fatalf("follow-up Chat lookup assistant/tool messages are not paired: call=%d output=%d body=%s", lookupCallIndex, lookupOutputIndex, body)
+	}
+	if !followup {
+		if foundLookupCall || foundLookupOutput {
+			t.Fatalf("initial Chat request unexpectedly contains lookup result pair: %s", body)
+		}
+	}
+	if searchInternalName == "" {
+		t.Fatalf("search assistant call did not expose internal function name: %s", body)
+	}
+	if followup && searchInternalName != searchName {
+		t.Fatalf("follow-up search function name=%q changed from captured initial name=%q: %s", searchInternalName, searchName, body)
+	}
+
+	var foundLoadedLookup bool
+	for _, tool := range gjson.GetBytes(body, "tools").Array() {
+		if tool.Get("type").String() != "function" || tool.Get("function.name").String() != proxyToolSearchLookupName {
+			continue
+		}
+		foundLoadedLookup = true
+		parameters := tool.Get("function.parameters")
+		if parameters.Get("type").String() != "object" ||
+			parameters.Get("properties.query.type").String() != "string" ||
+			parameters.Get("properties.limit.type").String() != "integer" ||
+			!parameters.Get("additionalProperties").Exists() ||
+			parameters.Get("additionalProperties").Bool() {
+			t.Fatalf("loaded lookup schema was not preserved: %s", body)
+		}
+		if parameters.Get("required.0").String() != "query" {
+			t.Fatalf("loaded lookup required schema was not preserved: %s", body)
+		}
+	}
+	if !foundLoadedLookup {
+		t.Fatalf("Chat tools did not contain flattened loaded lookup %q: %s", proxyToolSearchLookupName, body)
+	}
+
+	return searchInternalName
+}
+
+func assertProxyToolSearchClientFunctionCall(t *testing.T, body []byte, streaming bool, wantCallID string) {
+	t.Helper()
+	if !streaming {
+		if got := gjson.GetBytes(body, "object").String(); got != "response" {
+			t.Fatalf("function-call response object=%q, want response: %s", got, body)
+		}
+		assertProxyToolSearchFunctionCallItem(t, gjson.GetBytes(body, "output.0"), wantCallID)
+		return
+	}
+
+	for _, block := range bytes.Split(body, []byte("\n\n")) {
+		eventType, data := parseSSEEventChunk(block)
+		payload, ok := decodeSSEPayload(data)
+		if !ok || eventType != "response.output_item.done" {
+			continue
+		}
+		item, _ := payload["item"].(map[string]any)
+		if item["type"] != "function_call" {
+			continue
+		}
+		assertProxyToolSearchFunctionCall(t, gjson.ParseBytes(data).Get("item"), wantCallID)
+		return
+	}
+	t.Fatalf("stream did not contain function_call output item: %s", body)
+}
+
+func assertProxyToolSearchFunctionCallItem(t *testing.T, item gjson.Result, wantCallID string) {
+	t.Helper()
+	if item.Get("type").String() != "function_call" ||
+		item.Get("name").String() != "lookup" ||
+		item.Get("namespace").String() != "mcp__public" ||
+		item.Get("call_id").String() != wantCallID {
+		t.Fatalf("Responses function call identity = %s, want namespace=mcp__public name=lookup call_id=%s", item.Raw, wantCallID)
+	}
+}
+
+func assertProxyToolSearchFunctionCall(t *testing.T, item gjson.Result, wantCallID string) {
+	t.Helper()
+	assertProxyToolSearchFunctionCallItem(t, item, wantCallID)
+	arguments := item.Get("arguments")
+	if arguments.Type != gjson.String || gjson.Get(arguments.String(), "query").String() != "needle" {
+		t.Fatalf("Responses function call arguments=%s, want query=needle", arguments.Raw)
+	}
+}
+
+func assertProxyToolSearchCompletedResponse(t *testing.T, body []byte, streaming bool) {
+	t.Helper()
+	if !streaming {
+		if got := gjson.GetBytes(body, "status").String(); got != "completed" {
+			t.Fatalf("follow-up Responses status=%q, want completed: %s", got, body)
+		}
+		if got := gjson.GetBytes(body, "output.0.content.0.text").String(); got != proxyToolSearchResultToken {
+			t.Fatalf("follow-up Responses marker=%q, want %q: %s", got, proxyToolSearchResultToken, body)
+		}
+		return
+	}
+
+	var marker, status string
+	for _, block := range bytes.Split(body, []byte("\n\n")) {
+		eventType, data := parseSSEEventChunk(block)
+		payload, ok := decodeSSEPayload(data)
+		if !ok {
+			continue
+		}
+		switch eventType {
+		case "response.output_text.delta":
+			delta, _ := payload["delta"].(string)
+			marker += delta
+		case "response.completed":
+			response, _ := payload["response"].(map[string]any)
+			status, _ = response["status"].(string)
+		}
+	}
+	if marker != proxyToolSearchResultToken || status != "completed" {
+		t.Fatalf("follow-up Responses stream marker=%q status=%q, want marker=%q completed: %s", marker, status, proxyToolSearchResultToken, body)
+	}
+}

--- a/internal/protocol/builtin/cliproxy_adapter.go
+++ b/internal/protocol/builtin/cliproxy_adapter.go
@@ -152,7 +152,7 @@ func cliproxyAnthropicResponseToGeminiNonStream(ctx context.Context, model strin
 }
 
 func cliproxyCodexRequestToGemini(model string, raw []byte, stream bool) ([]byte, error) {
-	if err := cliproxyValidateCodexRequest(raw); err != nil {
+	if err := cliproxyValidateCodexRequest(raw, false); err != nil {
 		return nil, err
 	}
 	return cliproxyJSONRequest("codex request to gemini", raw, openairespgemini.ConvertOpenAIResponsesRequestToGemini(model, raw, stream))
@@ -183,7 +183,7 @@ func cliproxyCodexResponseToGeminiNonStream(ctx context.Context, model string, o
 }
 
 func cliproxyCodexRequestToAnthropic(model string, raw []byte, stream bool) ([]byte, error) {
-	if err := cliproxyValidateCodexRequest(raw); err != nil {
+	if err := cliproxyValidateCodexRequest(raw, false); err != nil {
 		return nil, err
 	}
 	return cliproxyJSONRequest("codex request to anthropic", raw, oairespclaude.ConvertOpenAIResponsesRequestToClaude(model, raw, stream))
@@ -221,10 +221,14 @@ func cliproxyCodexResponseToAnthropicNonStream(ctx context.Context, model string
 }
 
 func cliproxyCodexRequestToOpenAI(model string, raw []byte, stream bool) ([]byte, error) {
-	if err := cliproxyValidateCodexRequest(raw); err != nil {
+	if err := cliproxyValidateCodexRequest(raw, true); err != nil {
 		return nil, err
 	}
-	return cliproxyJSONRequest("codex request to openai", raw, openairesponses.ConvertOpenAIResponsesRequestToOpenAIChatCompletions(model, raw, stream))
+	translated, err := openairesponses.ConvertOpenAIResponsesRequestToOpenAIChatCompletionsWithError(model, raw, stream)
+	if err != nil {
+		return nil, err
+	}
+	return cliproxyJSONRequest("codex request to openai", raw, translated)
 }
 
 func cliproxyOpenAIResponseToCodexStream(ctx context.Context, model string, original, translated, raw []byte, param *any) ([][]byte, error) {
@@ -232,7 +236,11 @@ func cliproxyOpenAIResponseToCodexStream(ctx context.Context, model string, orig
 }
 
 func cliproxyOpenAIResponseToCodexNonStream(ctx context.Context, model string, original, translated, raw []byte) ([]byte, error) {
-	return cliproxyJSONResponse("openai response to codex", raw, openairesponses.ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(ctx, model, original, translated, raw, nil))
+	translatedResponse, err := openairesponses.ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStreamWithError(ctx, model, original, translated, raw, nil)
+	if err != nil {
+		return nil, err
+	}
+	return cliproxyJSONResponse("openai response to codex", raw, translatedResponse)
 }
 
 func cliproxyJSONRequest(label string, input []byte, output []byte) ([]byte, error) {
@@ -325,7 +333,7 @@ func cliproxyValidateAnthropicRequest(raw []byte) error {
 	return nil
 }
 
-func cliproxyValidateCodexRequest(raw []byte) error {
+func cliproxyValidateCodexRequest(raw []byte, allowToolSearch bool) error {
 	var request struct {
 		Input json.RawMessage `json:"input"`
 	}
@@ -374,6 +382,10 @@ func cliproxyValidateCodexRequest(raw []byte) error {
 				}
 			}
 		case "function_call", "function_call_output", "custom_tool_call", "custom_tool_call_output", "reasoning", "web_search_call", "computer_call", "computer_call_output", "image_generation_call", "local_shell_call", "local_shell_call_output", "shell_call", "shell_call_output", "apply_patch_call", "apply_patch_call_output", "additional_tools":
+		case "tool_search_call", "tool_search_output":
+			if !allowToolSearch {
+				return fmt.Errorf("unsupported Codex input item type %q for this provider", itemType)
+			}
 		default:
 			return fmt.Errorf("unsupported Codex input item type %q", itemType)
 		}
@@ -515,7 +527,11 @@ func cliproxyTranslateOpenAIToCodexStream(ctx context.Context, model string, ori
 	if state.response {
 		return nil, nil
 	}
-	return cliproxyFrameStreamChunks(cliproxyStreamCodex, openairesponses.ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx, model, original, translated, data, &state.chat))
+	chunks, err := openairesponses.ConvertOpenAIChatCompletionsResponseToOpenAIResponsesWithError(ctx, model, original, translated, data, &state.chat)
+	if err != nil {
+		return nil, err
+	}
+	return cliproxyFrameStreamChunks(cliproxyStreamCodex, chunks)
 }
 
 func cliproxyTranslateOpenAIToAnthropicStream(ctx context.Context, model string, original, translated, raw []byte, param *any) ([][]byte, error) {

--- a/internal/protocol/builtin/cliproxy_adapter_tool_search_test.go
+++ b/internal/protocol/builtin/cliproxy_adapter_tool_search_test.go
@@ -1,0 +1,49 @@
+package builtin
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestCodexToolSearchIsOnlyEnabledForOpenAIResponsesBridge(t *testing.T) {
+	raw := []byte(`{
+		"model":"gpt-5.4",
+		"tools":[{"type":"tool_search","execution":"client","parameters":{"type":"object"}}],
+		"input":[
+			{"type":"tool_search_call","execution":"client","call_id":"ts_1","arguments":{"goal":"find"}},
+			{"type":"tool_search_output","execution":"client","call_id":"ts_1","tools":[]}
+		]
+	}`)
+
+	translated, err := cliproxyCodexRequestToOpenAI("gpt-5.4", raw, false)
+	if err != nil {
+		t.Fatalf("OpenAI bridge rejected client tool_search: %v", err)
+	}
+	if got := gjson.GetBytes(translated, "tools.0.function.name").String(); got != "tool_search" {
+		t.Fatalf("unexpected translated search function %q: %s", got, translated)
+	}
+
+	if _, err := cliproxyCodexRequestToGemini("gpt-5.4", raw, false); err == nil || !strings.Contains(err.Error(), "tool_search") {
+		t.Fatalf("Gemini bridge should reject unimplemented tool_search, got %v", err)
+	}
+	if _, err := cliproxyCodexRequestToAnthropic("gpt-5.4", raw, false); err == nil || !strings.Contains(err.Error(), "tool_search") {
+		t.Fatalf("Anthropic bridge should reject unimplemented tool_search, got %v", err)
+	}
+}
+
+func TestOpenAIToCodexToolSearchResponseRejectsMalformedArguments(t *testing.T) {
+	request := []byte(`{"model":"gpt-5.4","tools":[{"type":"tool_search","execution":"client","parameters":{"type":"object"}}]}`)
+	nonStream := []byte(`{"id":"chat_1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","tool_calls":[{"id":"ts_1","type":"function","function":{"name":"tool_search","arguments":"{bad"}}]},"finish_reason":"tool_calls"}]}`)
+	if _, err := cliproxyOpenAIResponseToCodexNonStream(context.Background(), "gpt-5.4", request, request, nonStream); err == nil || !strings.Contains(err.Error(), "tool_search_call") {
+		t.Fatalf("expected non-stream translation error, got %v", err)
+	}
+
+	stream := []byte("data: {\"id\":\"chat_1\",\"object\":\"chat.completion.chunk\",\"created\":1710000000,\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"ts_1\",\"type\":\"function\",\"function\":{\"name\":\"tool_search\",\"arguments\":\"{bad\"}}]},\"finish_reason\":\"tool_calls\"}]}\n\n")
+	var state any
+	if _, err := cliproxyOpenAIResponseToCodexStream(context.Background(), "gpt-5.4", request, request, stream, &state); err == nil || !strings.Contains(err.Error(), "tool_search_call") {
+		t.Fatalf("expected stream translation error, got %v", err)
+	}
+}

--- a/internal/protocol/cliproxy/openai/openai/responses/openai_openai-responses_request.go
+++ b/internal/protocol/cliproxy/openai/openai/responses/openai_openai-responses_request.go
@@ -29,6 +29,21 @@ import (
 // Returns:
 //   - []byte: The transformed request data in OpenAI chat completions format
 func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inputRawJSON []byte, stream bool) []byte {
+	return convertOpenAIResponsesRequestToOpenAIChatCompletions(modelName, inputRawJSON, stream)
+}
+
+// ConvertOpenAIResponsesRequestToOpenAIChatCompletionsWithError converts a
+// Responses request while rejecting tool-search modes that cannot be
+// represented by Chat Completions. The legacy converter above remains a
+// best-effort API for callers that historically relied on a []byte result.
+func ConvertOpenAIResponsesRequestToOpenAIChatCompletionsWithError(modelName string, inputRawJSON []byte, stream bool) ([]byte, error) {
+	if err := validateOpenAIResponsesRequestForChat(inputRawJSON); err != nil {
+		return nil, err
+	}
+	return convertOpenAIResponsesRequestToOpenAIChatCompletions(modelName, inputRawJSON, stream), nil
+}
+
+func convertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inputRawJSON []byte, stream bool) []byte {
 	rawJSON := inputRawJSON
 	// Base OpenAI chat completions template with default values
 	out := []byte(`{"model":"","messages":[],"stream":false}`)
@@ -71,7 +86,7 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 		outputCallIDs := make(map[string]struct{})
 		for _, item := range inputItems {
 			itemType := item.Get("type").String()
-			if itemType != "function_call_output" && itemType != "custom_tool_call_output" {
+			if itemType != "function_call_output" && itemType != "custom_tool_call_output" && itemType != "tool_search_output" {
 				continue
 			}
 			callID := strings.TrimSpace(item.Get("call_id").String())
@@ -169,7 +184,7 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 			if itemType == "" && item.Get("role").String() != "" {
 				itemType = "message"
 			}
-			if itemType != "function_call" && itemType != "custom_tool_call" {
+			if itemType != "function_call" && itemType != "custom_tool_call" && itemType != "tool_search_call" {
 				flushPendingToolCalls()
 			}
 
@@ -271,6 +286,20 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 					pendingToolCallIDs = append(pendingToolCallIDs, callID)
 				}
 
+			case "tool_search_call":
+				pendingReasoningContent = combineOpenAIResponsesReasoning(pendingReasoningContent, item.Get("reasoning_content").String())
+				toolCall := []byte(`{"id":"","type":"function","function":{"name":"tool_search","arguments":""}}`)
+				callID := strings.TrimSpace(item.Get("call_id").String())
+				toolCall, _ = sjson.SetBytes(toolCall, "id", callID)
+				toolCall, _ = sjson.SetBytes(toolCall, "function.name", responsesChatToolSearchFunctionName)
+				if arguments, err := normalizeResponsesToolSearchArguments(item.Get("arguments")); err == nil {
+					toolCall, _ = sjson.SetBytes(toolCall, "function.arguments", arguments)
+				}
+				pendingToolCalls = append(pendingToolCalls, gjson.ParseBytes(toolCall).Value())
+				if callID != "" {
+					pendingToolCallIDs = append(pendingToolCallIDs, callID)
+				}
+
 			case "function_call_output":
 				mergeableAssistantIndex = -1
 				// Handle function call output conversion to tool message
@@ -286,6 +315,20 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 					toolMessage = setFunctionCallOutputContent(toolMessage, output)
 				}
 
+				appendMessage(toolMessage)
+				if callID != "" {
+					delete(awaitingToolOutputs, callID)
+				}
+				if len(awaitingToolOutputs) == 0 && len(deferredMessages) > 0 {
+					flushDeferredMessages()
+				}
+
+			case "tool_search_output":
+				mergeableAssistantIndex = -1
+				callID := strings.TrimSpace(item.Get("call_id").String())
+				toolMessage := []byte(`{"role":"tool","tool_call_id":"","content":""}`)
+				toolMessage, _ = sjson.SetBytes(toolMessage, "tool_call_id", callID)
+				toolMessage = setToolSearchOutputContent(toolMessage, item.Get("tools"))
 				appendMessage(toolMessage)
 				if callID != "" {
 					delete(awaitingToolOutputs, callID)

--- a/internal/protocol/cliproxy/openai/openai/responses/openai_openai-responses_response.go
+++ b/internal/protocol/cliproxy/openai/openai/responses/openai_openai-responses_response.go
@@ -47,12 +47,15 @@ type oaiToResponsesState struct {
 	// function item state
 	FuncItemAdded  map[string]bool
 	FuncItemCustom map[string]bool
+	FuncItemSearch map[string]bool
 	FuncArgsDone   map[string]bool
 	FuncItemDone   map[string]bool
 	// names of freeform ("custom") tools from the original request; calls to
 	// these are emitted as custom_tool_call items instead of function_call
 	CustomToolNames map[string]struct{}
+	ToolSearchNames map[string]struct{}
 	FinishReason    string
+	TranslationErr  error
 	// usage aggregation
 	PromptTokens     int64
 	CachedTokens     int64
@@ -218,6 +221,19 @@ func buildResponsesCompletedEvent(st *oaiToResponsesState, requestRawJSON []byte
 				outputItems = append(outputItems, completedOutputItem{index: st.FuncOutputIx[key], raw: item})
 				continue
 			}
+			if st.FuncItemSearch[key] {
+				argumentsJSON := responsesToolSearchArgumentsObject(args)
+				if len(argumentsJSON) == 0 {
+					continue
+				}
+				item := []byte(`{"id":"","type":"tool_search_call","status":"completed","execution":"client","arguments":{},"call_id":""}`)
+				item, _ = sjson.SetBytes(item, "id", fmt.Sprintf("tsc_%s", callID))
+				item, _ = sjson.SetBytes(item, "status", toolStatus)
+				item, _ = sjson.SetRawBytes(item, "arguments", argumentsJSON)
+				item, _ = sjson.SetBytes(item, "call_id", callID)
+				outputItems = append(outputItems, completedOutputItem{index: st.FuncOutputIx[key], raw: item})
+				continue
+			}
 			item := []byte(`{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}`)
 			item, _ = sjson.SetBytes(item, "id", fmt.Sprintf("fc_%s", callID))
 			item, _ = sjson.SetBytes(item, "status", toolStatus)
@@ -251,9 +267,39 @@ func buildResponsesCompletedEvent(st *oaiToResponsesState, requestRawJSON []byte
 	return emitRespEvent(eventType, completed)
 }
 
-// ConvertOpenAIChatCompletionsResponseToOpenAIResponses converts OpenAI Chat Completions streaming chunks
-// to OpenAI Responses SSE events (response.*).
+// ConvertOpenAIChatCompletionsResponseToOpenAIResponses converts OpenAI Chat
+// Completions streaming chunks to OpenAI Responses SSE events (response.*).
+// It retains the historical best-effort signature for callers that cannot
+// return a conversion error; invalid client tool-search calls are omitted.
 func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, modelName string, originalRequestRawJSON, requestRawJSON, rawJSON []byte, param *any) [][]byte {
+	chunks, _ := ConvertOpenAIChatCompletionsResponseToOpenAIResponsesWithError(ctx, modelName, originalRequestRawJSON, requestRawJSON, rawJSON, param)
+	return chunks
+}
+
+// ConvertOpenAIChatCompletionsResponseToOpenAIResponsesWithError is the
+// error-aware streaming converter used by the protocol registry. It rejects
+// malformed client tool-search arguments before a terminal search call or
+// response.completed event can be exposed.
+func ConvertOpenAIChatCompletionsResponseToOpenAIResponsesWithError(ctx context.Context, modelName string, originalRequestRawJSON, requestRawJSON, rawJSON []byte, param *any) ([][]byte, error) {
+	if param == nil {
+		return nil, fmt.Errorf("OpenAI Responses stream conversion requires state")
+	}
+	if *param != nil {
+		if st, ok := (*param).(*oaiToResponsesState); ok && st.TranslationErr != nil {
+			return nil, st.TranslationErr
+		}
+	}
+	chunks := convertOpenAIChatCompletionsResponseToOpenAIResponses(ctx, modelName, originalRequestRawJSON, requestRawJSON, rawJSON, param)
+	if st, ok := (*param).(*oaiToResponsesState); ok && openAIChatCompletionChunkIsTerminal(rawJSON) {
+		if err := validateOpenAIChatCompletionsToolSearchState(st); err != nil {
+			st.TranslationErr = err
+			return nil, err
+		}
+	}
+	return chunks, nil
+}
+
+func convertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, modelName string, originalRequestRawJSON, requestRawJSON, rawJSON []byte, param *any) [][]byte {
 	if *param == nil {
 		*param = &oaiToResponsesState{
 			FuncArgsBuf:     make(map[string]*strings.Builder),
@@ -268,6 +314,7 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 			MsgItemDone:     make(map[int]bool),
 			FuncItemAdded:   make(map[string]bool),
 			FuncItemCustom:  make(map[string]bool),
+			FuncItemSearch:  make(map[string]bool),
 			FuncArgsDone:    make(map[string]bool),
 			FuncItemDone:    make(map[string]bool),
 			Reasonings:      make([]oaiToResponsesStateReasoning, 0),
@@ -359,8 +406,17 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 
 		outputIndex := st.FuncOutputIx[key]
 		_, isCustomTool := st.CustomToolNames[name]
+		_, isSearchTool := st.ToolSearchNames[name]
 		st.FuncItemCustom[key] = isCustomTool
-		if isCustomTool {
+		st.FuncItemSearch[key] = isSearchTool
+		if isSearchTool {
+			o := []byte(`{"type":"response.output_item.added","sequence_number":0,"output_index":0,"item":{"id":"","type":"tool_search_call","status":"in_progress","execution":"client","arguments":{},"call_id":""}}`)
+			o, _ = sjson.SetBytes(o, "sequence_number", nextSeq())
+			o, _ = sjson.SetBytes(o, "output_index", outputIndex)
+			o, _ = sjson.SetBytes(o, "item.id", fmt.Sprintf("tsc_%s", callID))
+			o, _ = sjson.SetBytes(o, "item.call_id", callID)
+			out = append(out, emitRespEvent("response.output_item.added", o))
+		} else if isCustomTool {
 			o := []byte(`{"type":"response.output_item.added","sequence_number":0,"output_index":0,"item":{"id":"","type":"custom_tool_call","status":"in_progress","input":"","call_id":"","name":""}}`)
 			o, _ = sjson.SetBytes(o, "sequence_number", nextSeq())
 			o, _ = sjson.SetBytes(o, "output_index", outputIndex)
@@ -380,7 +436,7 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 		st.FuncItemAdded[key] = true
 	}
 	emitPendingFunctionArgs := func(key string) {
-		if !st.FuncItemAdded[key] || st.FuncItemCustom[key] {
+		if !st.FuncItemAdded[key] || st.FuncItemCustom[key] || st.FuncItemSearch[key] {
 			return
 		}
 		argsBuf := st.FuncArgsBuf[key]
@@ -419,15 +475,18 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 		st.MsgItemDone = make(map[int]bool)
 		st.FuncItemAdded = make(map[string]bool)
 		st.FuncItemCustom = make(map[string]bool)
+		st.FuncItemSearch = make(map[string]bool)
 		st.FuncArgsDone = make(map[string]bool)
 		st.FuncItemDone = make(map[string]bool)
 		st.CustomToolNames = responsesCustomToolNames(requestForNamespace)
+		st.ToolSearchNames = responsesToolSearchNames(requestForNamespace)
 		st.PromptTokens = 0
 		st.CachedTokens = 0
 		st.CompletionTokens = 0
 		st.TotalTokens = 0
 		st.ReasoningTokens = 0
 		st.FinishReason = ""
+		st.TranslationErr = nil
 		st.UsageSeen = false
 		st.CompletedEmitted = false
 		// response.created
@@ -578,6 +637,23 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 			}
 			if isIncomplete {
 				toolStatus = "incomplete"
+			}
+			if st.FuncItemSearch[key] {
+				argumentsJSON := responsesToolSearchArgumentsObject(args)
+				if len(argumentsJSON) == 0 {
+					continue
+				}
+				itemDone := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"tool_search_call","status":"completed","execution":"client","arguments":{},"call_id":""}}`)
+				itemDone, _ = sjson.SetBytes(itemDone, "sequence_number", nextSeq())
+				itemDone, _ = sjson.SetBytes(itemDone, "output_index", outputIndex)
+				itemDone, _ = sjson.SetBytes(itemDone, "item.id", fmt.Sprintf("tsc_%s", callID))
+				itemDone, _ = sjson.SetBytes(itemDone, "item.status", toolStatus)
+				itemDone, _ = sjson.SetRawBytes(itemDone, "item.arguments", argumentsJSON)
+				itemDone, _ = sjson.SetBytes(itemDone, "item.call_id", callID)
+				out = append(out, emitRespEvent("response.output_item.done", itemDone))
+				st.FuncItemDone[key] = true
+				st.FuncArgsDone[key] = true
+				continue
 			}
 			if st.FuncItemCustom[key] {
 				input := unwrapCustomToolInput(args)
@@ -772,9 +848,29 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 	return out
 }
 
-// ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream builds a single Responses JSON
-// from a non-streaming OpenAI Chat Completions response.
-func ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(_ context.Context, _ string, originalRequestRawJSON, requestRawJSON, rawJSON []byte, _ *any) []byte {
+// ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream builds a
+// single Responses JSON from a non-streaming OpenAI Chat Completions response.
+// It retains the historical best-effort signature; callers that need to
+// distinguish a malformed client tool-search call should use the error-aware
+// variant below.
+func ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(ctx context.Context, modelName string, originalRequestRawJSON, requestRawJSON, rawJSON []byte, param *any) []byte {
+	response, _ := ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStreamWithError(ctx, modelName, originalRequestRawJSON, requestRawJSON, rawJSON, param)
+	return response
+}
+
+// ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStreamWithError rejects
+// malformed client tool-search arguments before constructing a
+// completed Responses response. Ordinary function-call arguments preserve
+// their existing best-effort conversion.
+func ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStreamWithError(_ context.Context, _ string, originalRequestRawJSON, requestRawJSON, rawJSON []byte, _ *any) ([]byte, error) {
+	requestForNamespace := pickRequestJSON(originalRequestRawJSON, requestRawJSON)
+	if err := validateOpenAIChatCompletionsToolSearchArguments(requestForNamespace, rawJSON); err != nil {
+		return nil, err
+	}
+	return convertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(originalRequestRawJSON, requestRawJSON, rawJSON), nil
+}
+
+func convertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(originalRequestRawJSON, requestRawJSON, rawJSON []byte) []byte {
 	root := gjson.ParseBytes(rawJSON)
 	requestForNamespace := pickRequestJSON(originalRequestRawJSON, requestRawJSON)
 
@@ -948,6 +1044,7 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(_ context.Co
 				// Function/tool calls
 				if tcs := msg.Get("tool_calls"); tcs.Exists() && tcs.IsArray() {
 					customToolNames := responsesCustomToolNames(requestForNamespace)
+					toolSearchNames := responsesToolSearchNames(requestForNamespace)
 					tcs.ForEach(func(tcIndex, tc gjson.Result) bool {
 						callID := tc.Get("id").String()
 						if callID == "" {
@@ -960,6 +1057,19 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(_ context.Co
 						toolStatus := "completed"
 						if isIncomplete {
 							toolStatus = "incomplete"
+						}
+						if _, isSearchTool := toolSearchNames[name]; isSearchTool {
+							argumentsJSON := responsesToolSearchArgumentsObject(args)
+							if len(argumentsJSON) == 0 {
+								return true
+							}
+							item := []byte(`{"id":"","type":"tool_search_call","status":"completed","execution":"client","arguments":{},"call_id":""}`)
+							item, _ = sjson.SetBytes(item, "id", fmt.Sprintf("tsc_%s", callID))
+							item, _ = sjson.SetBytes(item, "status", toolStatus)
+							item, _ = sjson.SetRawBytes(item, "arguments", argumentsJSON)
+							item, _ = sjson.SetBytes(item, "call_id", callID)
+							outputItems = append(outputItems, item)
+							return true
 						}
 						if _, isCustomTool := customToolNames[name]; isCustomTool {
 							item := []byte(`{"id":"","type":"custom_tool_call","status":"completed","input":"","call_id":"","name":""}`)

--- a/internal/protocol/cliproxy/openai/openai/responses/openai_openai-responses_tool_search.go
+++ b/internal/protocol/cliproxy/openai/openai/responses/openai_openai-responses_tool_search.go
@@ -1,0 +1,435 @@
+package responses
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// Chat Completions has no tool-search item type. A client-executed Responses
+// tool_search is represented as one ordinary function so that the model can
+// still ask the host to perform the search and the original call_id can be
+// paired with the following tool output.
+const responsesChatToolSearchFunctionName = "tool_search"
+
+type responsesToolSearchDeclaration struct {
+	tool gjson.Result
+}
+
+func walkResponsesToolSearchDeclarations(root gjson.Result, visit func(responsesToolSearchDeclaration) bool) {
+	proceed := true
+	scan := func(tools gjson.Result) {
+		if !proceed || !tools.Exists() || !tools.IsArray() {
+			return
+		}
+		tools.ForEach(func(_, tool gjson.Result) bool {
+			if strings.TrimSpace(tool.Get("type").String()) == "tool_search" {
+				proceed = visit(responsesToolSearchDeclaration{tool: tool})
+			}
+			return proceed
+		})
+	}
+
+	scan(root.Get("tools"))
+	if input := root.Get("input"); input.Exists() && input.IsArray() {
+		input.ForEach(func(_, item gjson.Result) bool {
+			switch strings.TrimSpace(item.Get("type").String()) {
+			case "additional_tools":
+				scan(item.Get("tools"))
+			case "tool_search_output":
+				// The output carries the tools loaded by the client. Those
+				// declarations are regular function/custom/namespace tools;
+				// a nested tool_search is not meaningful and is rejected by
+				// validation rather than being treated as a new search tool.
+			}
+			return proceed
+		})
+	}
+}
+
+func responsesToolSearchNames(requestRawJSON []byte) map[string]struct{} {
+	names := make(map[string]struct{})
+	root := gjson.ParseBytes(requestRawJSON)
+	walkResponsesToolSearchDeclarations(root, func(responsesToolSearchDeclaration) bool {
+		names[responsesChatToolSearchFunctionName] = struct{}{}
+		return true
+	})
+	if input := root.Get("input"); input.Exists() && input.IsArray() {
+		input.ForEach(func(_, item gjson.Result) bool {
+			switch strings.TrimSpace(item.Get("type").String()) {
+			case "tool_search_call", "tool_search_output":
+				names[responsesChatToolSearchFunctionName] = struct{}{}
+			}
+			return true
+		})
+	}
+	return names
+}
+
+// normalizeResponsesToolSearchArguments returns the object JSON required by
+// Responses tool_search_call. The Responses API normally sends an object, but
+// accepting a JSON object string here keeps replayed history compatible with
+// clients that serialize all tool arguments as strings.
+func normalizeResponsesToolSearchArguments(value gjson.Result) (string, error) {
+	if !value.Exists() {
+		return "", fmt.Errorf("tool_search_call.arguments is required")
+	}
+	candidate := value
+	if value.Type == gjson.String {
+		if !gjson.Valid(value.String()) {
+			return "", fmt.Errorf("tool_search_call.arguments must be an object")
+		}
+		candidate = gjson.Parse(value.String())
+	}
+	if !candidate.IsObject() {
+		return "", fmt.Errorf("tool_search_call.arguments must be an object")
+	}
+	if !json.Valid([]byte(candidate.Raw)) {
+		return "", fmt.Errorf("tool_search_call.arguments must be valid JSON")
+	}
+	return candidate.Raw, nil
+}
+
+func responsesToolSearchArgumentsObject(arguments string) []byte {
+	if raw, err := normalizeResponsesToolSearchArguments(gjson.Parse(arguments)); err == nil {
+		return []byte(raw)
+	}
+	// An invalid search call must never be represented as an executable
+	// Responses item. Error-aware response conversion reports the validation
+	// error to its caller; this helper returns nil for the legacy best-effort
+	// converter so it cannot manufacture a successful call payload.
+	return nil
+}
+
+func setToolSearchOutputContent(toolMessage []byte, tools gjson.Result) []byte {
+	if tools.Exists() && tools.IsArray() {
+		// Chat tool messages have string content. Keeping the loaded tool
+		// declarations as JSON preserves namespace/function metadata for the
+		// next Responses request and is also readable by ordinary providers.
+		toolMessage, _ = sjson.SetBytes(toolMessage, "content", tools.Raw)
+		return toolMessage
+	}
+	toolMessage, _ = sjson.SetBytes(toolMessage, "content", "[]")
+	return toolMessage
+}
+
+func responsesRequestHasToolSearch(root gjson.Result) bool {
+	found := false
+	scan := func(tools gjson.Result) {
+		if found || !tools.Exists() || !tools.IsArray() {
+			return
+		}
+		tools.ForEach(func(_, tool gjson.Result) bool {
+			if strings.TrimSpace(tool.Get("type").String()) == "tool_search" {
+				found = true
+				return false
+			}
+			return true
+		})
+	}
+	scan(root.Get("tools"))
+	if input := root.Get("input"); input.Exists() && input.IsArray() {
+		input.ForEach(func(_, item gjson.Result) bool {
+			typeName := strings.TrimSpace(item.Get("type").String())
+			if typeName == "tool_search_call" || typeName == "tool_search_output" {
+				found = true
+				return false
+			}
+			if typeName == "additional_tools" {
+				scan(item.Get("tools"))
+			}
+			return !found
+		})
+	}
+	return found
+}
+
+func validateOpenAIResponsesRequestForChat(raw []byte) error {
+	if !gjson.ValidBytes(raw) {
+		return fmt.Errorf("invalid OpenAI Responses request JSON")
+	}
+	root := gjson.ParseBytes(raw)
+	if !root.IsObject() {
+		return fmt.Errorf("OpenAI Responses request must be a JSON object")
+	}
+	// Keep the historical best-effort behavior for ordinary Responses tools.
+	// This validator is only strict when a request actually uses client tool
+	// search or replays one of its input/output items.
+	if !responsesRequestHasToolSearch(root) {
+		return nil
+	}
+
+	searchDeclarationCount := 0
+	searchCallIDs := make(map[string]struct{})
+	searchOutputIDs := make(map[string]struct{})
+
+	var validateToolArray func(gjson.Result, string, bool, bool) error
+	validateToolArray = func(tools gjson.Result, path string, allowSearch, strict bool) error {
+		if !tools.Exists() {
+			return nil
+		}
+		if !tools.IsArray() {
+			return fmt.Errorf("%s must be an array", path)
+		}
+		for index, tool := range tools.Array() {
+			if !tool.IsObject() {
+				return fmt.Errorf("%s[%d] must be an object", path, index)
+			}
+			typeName := strings.TrimSpace(tool.Get("type").String())
+			switch typeName {
+			case "", "function", "custom":
+				if strict && responsesToolName(tool) == "" {
+					return fmt.Errorf("%s[%d] %s tool name is required", path, index, typeName)
+				}
+			case "namespace":
+				if !strict {
+					continue
+				}
+				if strings.TrimSpace(tool.Get("name").String()) == "" {
+					return fmt.Errorf("%s[%d] namespace name is required", path, index)
+				}
+				children := tool.Get("tools")
+				if !children.Exists() || !children.IsArray() {
+					return fmt.Errorf("%s[%d].tools must be an array", path, index)
+				}
+				for childIndex, child := range children.Array() {
+					childType := strings.TrimSpace(child.Get("type").String())
+					if childType == "namespace" {
+						return fmt.Errorf("%s[%d].tools[%d] nested namespace tools are not convertible to Chat Completions", path, index, childIndex)
+					}
+				}
+				if err := validateToolArray(children, fmt.Sprintf("%s[%d].tools", path, index), false, true); err != nil {
+					return err
+				}
+			case "tool_search":
+				if !allowSearch {
+					return fmt.Errorf("%s[%d] tool_search declarations are only valid at request level", path, index)
+				}
+				if strings.TrimSpace(tool.Get("execution").String()) != "client" {
+					return fmt.Errorf("%s[%d] tool_search execution must be \"client\" for Chat Completions conversion", path, index)
+				}
+				searchDeclarationCount++
+				if parameters := tool.Get("parameters"); parameters.Exists() && !parameters.IsObject() {
+					return fmt.Errorf("%s[%d].parameters must be an object", path, index)
+				}
+			case "web_search", "web_search_preview", "web_search_preview_2025_03_11":
+				// The existing adapter maps Responses web_search tools to
+				// Chat's web_search_options rather than a function tool.
+				if strict {
+					return fmt.Errorf("%s[%d] Responses tool type %q is not convertible to a loaded Chat Completions function", path, index, typeName)
+				}
+			default:
+				if strings.HasPrefix(typeName, "web_search") {
+					continue
+				}
+				if strict {
+					return fmt.Errorf("%s[%d] Responses tool type %q is not convertible to Chat Completions", path, index, typeName)
+				}
+			}
+		}
+		return nil
+	}
+
+	if err := validateToolArray(root.Get("tools"), "tools", true, false); err != nil {
+		return err
+	}
+	checkReservedToolCollision := func() error {
+		if !responsesRequestHasToolSearch(root) {
+			return nil
+		}
+		collision := false
+		walkResponsesToolDeclarations(root, func(declaration responsesToolDeclaration) bool {
+			if declaration.chatName == responsesChatToolSearchFunctionName {
+				collision = true
+				return false
+			}
+			return true
+		})
+		if collision {
+			return fmt.Errorf("a regular Responses tool already uses reserved Chat function name %q", responsesChatToolSearchFunctionName)
+		}
+		return nil
+	}
+	input := root.Get("input")
+	if input.Exists() && !input.IsArray() && input.Type != gjson.String {
+		return fmt.Errorf("input must be a string or array")
+	}
+
+	// Validate additional tool declarations and collect search calls before
+	// checking outputs, so pairing remains correct even for replay histories
+	// whose items were reordered by a client.
+	if input.IsArray() {
+		for index, item := range input.Array() {
+			if strings.TrimSpace(item.Get("type").String()) == "additional_tools" {
+				if err := validateToolArray(item.Get("tools"), fmt.Sprintf("input[%d].tools", index), true, false); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	if searchDeclarationCount > 1 {
+		return fmt.Errorf("multiple client tool_search declarations cannot be mapped to one Chat Completions function")
+	}
+	if err := checkReservedToolCollision(); err != nil {
+		return err
+	}
+	if !input.IsArray() {
+		return nil
+	}
+	for index, item := range input.Array() {
+		if strings.TrimSpace(item.Get("type").String()) != "tool_search_call" {
+			continue
+		}
+		if strings.TrimSpace(item.Get("execution").String()) != "client" {
+			return fmt.Errorf("input[%d] tool_search_call execution must be \"client\" for Chat Completions conversion", index)
+		}
+		callID := strings.TrimSpace(item.Get("call_id").String())
+		if callID == "" {
+			return fmt.Errorf("input[%d] tool_search_call.call_id is required", index)
+		}
+		if _, duplicate := searchCallIDs[callID]; duplicate {
+			return fmt.Errorf("input[%d] duplicate tool_search_call.call_id %q", index, callID)
+		}
+		if _, err := normalizeResponsesToolSearchArguments(item.Get("arguments")); err != nil {
+			return fmt.Errorf("input[%d]: %w", index, err)
+		}
+		searchCallIDs[callID] = struct{}{}
+	}
+	for index, item := range input.Array() {
+		if strings.TrimSpace(item.Get("type").String()) != "tool_search_output" {
+			continue
+		}
+		if strings.TrimSpace(item.Get("execution").String()) != "client" {
+			return fmt.Errorf("input[%d] tool_search_output execution must be \"client\" for Chat Completions conversion", index)
+		}
+		callID := strings.TrimSpace(item.Get("call_id").String())
+		if callID == "" {
+			return fmt.Errorf("input[%d] tool_search_output.call_id is required", index)
+		}
+		if _, duplicate := searchOutputIDs[callID]; duplicate {
+			return fmt.Errorf("input[%d] duplicate tool_search_output.call_id %q", index, callID)
+		}
+		tools := item.Get("tools")
+		if !tools.Exists() || !tools.IsArray() {
+			return fmt.Errorf("input[%d] tool_search_output.tools must be an array", index)
+		}
+		if err := validateToolArray(tools, fmt.Sprintf("input[%d].tools", index), false, true); err != nil {
+			return err
+		}
+		if _, paired := searchCallIDs[callID]; !paired {
+			return fmt.Errorf("input[%d] tool_search_output.call_id %q has no matching tool_search_call", index, callID)
+		}
+		searchOutputIDs[callID] = struct{}{}
+	}
+	for callID := range searchCallIDs {
+		if _, paired := searchOutputIDs[callID]; !paired {
+			return fmt.Errorf("tool_search_call.call_id %q has no matching tool_search_output; replay the complete search history", callID)
+		}
+	}
+	return nil
+}
+
+// validateOpenAIChatCompletionsToolSearchArguments checks only calls that are
+// known to be the reserved client tool-search function. Ordinary function
+// calls continue through the historical best-effort response converter,
+// including when their argument text is malformed.
+func validateOpenAIChatCompletionsToolSearchArguments(requestForNamespace, responseRawJSON []byte) error {
+	if len(requestForNamespace) == 0 || !gjson.ValidBytes(requestForNamespace) {
+		return nil
+	}
+	searchNames := responsesToolSearchNames(requestForNamespace)
+	if len(searchNames) == 0 {
+		return nil
+	}
+
+	root := gjson.ParseBytes(responseRawJSON)
+	choices := root.Get("choices")
+	if !choices.Exists() || !choices.IsArray() {
+		return nil
+	}
+	var validationErr error
+	choices.ForEach(func(_, choice gjson.Result) bool {
+		if validationErr != nil {
+			return false
+		}
+		toolCalls := choice.Get("message.tool_calls")
+		if !toolCalls.Exists() || !toolCalls.IsArray() {
+			return true
+		}
+		toolCalls.ForEach(func(_, toolCall gjson.Result) bool {
+			name := strings.TrimSpace(toolCall.Get("function.name").String())
+			if _, isSearchTool := searchNames[name]; !isSearchTool {
+				return true
+			}
+			arguments := toolCall.Get("function.arguments")
+			if _, err := normalizeResponsesToolSearchArguments(gjson.Parse(arguments.String())); err != nil {
+				callID := strings.TrimSpace(toolCall.Get("id").String())
+				if callID == "" {
+					returnErr := fmt.Errorf("tool_search_call.arguments: %w", err)
+					validationErr = returnErr
+				} else {
+					validationErr = fmt.Errorf("tool_search_call %q.arguments: %w", callID, err)
+				}
+				return false
+			}
+			return true
+		})
+		return validationErr == nil
+	})
+	return validationErr
+}
+
+// validateOpenAIChatCompletionsToolSearchState checks an aggregated streaming
+// call after the provider has declared a terminal finish reason or sent
+// [DONE]. A partial argument buffer is therefore treated as invalid rather
+// than being exposed as a completed executable search call.
+func validateOpenAIChatCompletionsToolSearchState(st *oaiToResponsesState) error {
+	if st == nil {
+		return nil
+	}
+	for key, name := range st.FuncNames {
+		if _, isSearchTool := st.ToolSearchNames[name]; !isSearchTool {
+			continue
+		}
+		arguments := ""
+		if buffer := st.FuncArgsBuf[key]; buffer != nil {
+			arguments = buffer.String()
+		}
+		if _, err := normalizeResponsesToolSearchArguments(gjson.Parse(arguments)); err != nil {
+			callID := strings.TrimSpace(st.FuncCallIDs[key])
+			if callID == "" {
+				return fmt.Errorf("tool_search_call.arguments: %w", err)
+			}
+			return fmt.Errorf("tool_search_call %q.arguments: %w", callID, err)
+		}
+	}
+	return nil
+}
+
+func openAIChatCompletionChunkIsTerminal(rawJSON []byte) bool {
+	rawJSON = bytes.TrimSpace(rawJSON)
+	if bytes.HasPrefix(rawJSON, []byte("data:")) {
+		rawJSON = bytes.TrimSpace(rawJSON[5:])
+	}
+	if bytes.Equal(rawJSON, []byte("[DONE]")) {
+		return true
+	}
+	root := gjson.ParseBytes(rawJSON)
+	choices := root.Get("choices")
+	if !choices.Exists() || !choices.IsArray() {
+		return false
+	}
+	terminal := false
+	choices.ForEach(func(_, choice gjson.Result) bool {
+		if finishReason := choice.Get("finish_reason"); finishReason.Exists() && strings.TrimSpace(finishReason.String()) != "" {
+			terminal = true
+			return false
+		}
+		return true
+	})
+	return terminal
+}

--- a/internal/protocol/cliproxy/openai/openai/responses/openai_openai-responses_tool_search_test.go
+++ b/internal/protocol/cliproxy/openai/openai/responses/openai_openai-responses_tool_search_test.go
@@ -1,0 +1,226 @@
+package responses
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestToolSearchRequestMapsCallOutputAndLoadedNamespaceTools(t *testing.T) {
+	raw := []byte(`{
+		"model":"gpt-5.4",
+		"tools":[{"type":"tool_search","execution":"client","description":"Load a tool","parameters":{"type":"object","properties":{"goal":{"type":"string"}}}}],
+		"input":[
+			{"type":"tool_search_call","execution":"client","call_id":"ts_1","status":"completed","arguments":{"goal":"shipping"}},
+			{"type":"tool_search_output","execution":"client","call_id":"ts_1","status":"completed","tools":[{"type":"namespace","name":"shipping","tools":[{"type":"function","name":"get_eta","description":"Get ETA","parameters":{"type":"object"}}]}]},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"continue"}]}
+		]
+	}`)
+
+	out, err := ConvertOpenAIResponsesRequestToOpenAIChatCompletionsWithError("gpt-5.4", raw, false)
+	if err != nil {
+		t.Fatalf("convert request: %v", err)
+	}
+	root := gjson.ParseBytes(out)
+	if got := root.Get("tools.#").Int(); got != 2 {
+		t.Fatalf("expected tool_search plus loaded tool, got %d: %s", got, out)
+	}
+	if got := root.Get("tools.0.function.name").String(); got != responsesChatToolSearchFunctionName {
+		t.Fatalf("unexpected search function name %q", got)
+	}
+	if got := root.Get("tools.1.function.name").String(); got != "shipping__get_eta" {
+		t.Fatalf("loaded namespace was not flattened: %q", got)
+	}
+	if got := root.Get("messages.0.tool_calls.0.id").String(); got != "ts_1" {
+		t.Fatalf("call_id was not preserved in assistant tool call: %q", got)
+	}
+	if got := root.Get("messages.0.tool_calls.0.function.name").String(); got != responsesChatToolSearchFunctionName {
+		t.Fatalf("unexpected assistant search name %q", got)
+	}
+	if got := root.Get("messages.0.tool_calls.0.function.arguments").String(); got != `{"goal":"shipping"}` {
+		t.Fatalf("unexpected search arguments %q", got)
+	}
+	if got := root.Get("messages.1.tool_call_id").String(); got != "ts_1" {
+		t.Fatalf("tool output was not paired: %q", got)
+	}
+	if !strings.Contains(root.Get("messages.1.content").String(), "get_eta") {
+		t.Fatalf("loaded tools were dropped from tool output: %q", root.Get("messages.1.content").String())
+	}
+
+	// The loaded declaration is also the source of truth for reverse namespace
+	// restoration when the provider calls it on the next turn.
+	chatResponse := []byte(`{"id":"chat_1","object":"chat.completion","created":1710000000,"choices":[{"index":0,"message":{"role":"assistant","tool_calls":[{"id":"call_2","type":"function","function":{"name":"shipping__get_eta","arguments":"{\"order\":\"A\"}"}}]},"finish_reason":"tool_calls"}]}`)
+	responses := ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(context.Background(), "gpt-5.4", raw, out, chatResponse, nil)
+	responseRoot := gjson.ParseBytes(responses)
+	if got := responseRoot.Get("output.0.type").String(); got != "function_call" {
+		t.Fatalf("unexpected reverse item type %q", got)
+	}
+	if got := responseRoot.Get("output.0.name").String(); got != "get_eta" {
+		t.Fatalf("namespace child was not restored: %q", got)
+	}
+	if got := responseRoot.Get("output.0.namespace").String(); got != "shipping" {
+		t.Fatalf("namespace was not restored: %q", got)
+	}
+}
+
+func TestToolSearchRequestRejectsMissingHistoryEvenWithPreviousResponse(t *testing.T) {
+	raw := []byte(`{
+		"model":"gpt-5.4",
+		"previous_response_id":"resp_1",
+		"input":[{"type":"tool_search_output","execution":"client","call_id":"ts_1","status":"completed","tools":[{"type":"function","name":"get_eta","parameters":{"type":"object"}}]}]
+	}`)
+	_, err := ConvertOpenAIResponsesRequestToOpenAIChatCompletionsWithError("gpt-5.4", raw, false)
+	if err == nil || !strings.Contains(err.Error(), "matching tool_search_call") {
+		t.Fatalf("expected missing history error, got %v", err)
+	}
+}
+
+func TestToolSearchRequestRejectsUnsupportedHistoryAndModes(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "server declaration",
+			raw:  `{"tools":[{"type":"tool_search","execution":"server"}]}`,
+			want: "execution must be",
+		},
+		{
+			name: "call without output",
+			raw:  `{"input":[{"type":"tool_search_call","execution":"client","call_id":"ts_1","arguments":{"goal":"x"}}]}`,
+			want: "matching tool_search_output",
+		},
+		{
+			name: "output without call",
+			raw:  `{"input":[{"type":"tool_search_output","execution":"client","call_id":"ts_1","tools":[]}]}`,
+			want: "matching tool_search_call",
+		},
+		{
+			name: "invalid arguments",
+			raw:  `{"input":[{"type":"tool_search_call","execution":"client","call_id":"ts_1","arguments":["bad"]},{"type":"tool_search_output","execution":"client","call_id":"ts_1","tools":[]}]}`,
+			want: "arguments must be an object",
+		},
+		{
+			name: "reserved name collision from history",
+			raw:  `{"tools":[{"type":"function","name":"tool_search"}],"input":[{"type":"tool_search_call","execution":"client","call_id":"ts_1","arguments":{}},{"type":"tool_search_output","execution":"client","call_id":"ts_1","tools":[]}]}`,
+			want: "reserved Chat function name",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ConvertOpenAIResponsesRequestToOpenAIChatCompletionsWithError("gpt-5.4", []byte(tt.raw), false)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected error containing %q, got %v", tt.want, err)
+			}
+		})
+	}
+}
+
+func TestToolSearchValidationLeavesOrdinaryUnsupportedToolsUntouched(t *testing.T) {
+	raw := []byte(`{"tools":[{"type":"mcp","server_label":"existing"}],"input":"hello"}`)
+	if _, err := ConvertOpenAIResponsesRequestToOpenAIChatCompletionsWithError("gpt-5.4", raw, false); err != nil {
+		t.Fatalf("ordinary tool validation changed without tool_search: %v", err)
+	}
+}
+
+func TestToolSearchResponseNonStreamRestoresSearchCall(t *testing.T) {
+	request := []byte(`{"model":"gpt-5.4","tools":[{"type":"tool_search","execution":"client","parameters":{"type":"object"}}]}`)
+	chatResponse := []byte(`{"id":"chat_1","object":"chat.completion","created":1710000000,"choices":[{"index":0,"message":{"role":"assistant","tool_calls":[{"id":"ts_1","type":"function","function":{"name":"tool_search","arguments":"{\"goal\":\"shipping\"}"}}]},"finish_reason":"tool_calls"}]}`)
+	out := ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(context.Background(), "gpt-5.4", request, request, chatResponse, nil)
+	root := gjson.ParseBytes(out)
+	item := root.Get("output.0")
+	if got := item.Get("type").String(); got != "tool_search_call" {
+		t.Fatalf("unexpected item type %q: %s", got, out)
+	}
+	if got := item.Get("execution").String(); got != "client" {
+		t.Fatalf("unexpected execution %q", got)
+	}
+	if got := item.Get("call_id").String(); got != "ts_1" {
+		t.Fatalf("unexpected call_id %q", got)
+	}
+	if got := item.Get("arguments.goal").String(); got != "shipping" {
+		t.Fatalf("unexpected arguments %s", item.Get("arguments").Raw)
+	}
+}
+
+func TestToolSearchResponseRejectsInvalidArgumentsWithoutCompletedCall(t *testing.T) {
+	request := []byte(`{"model":"gpt-5.4","tools":[{"type":"tool_search","execution":"client","parameters":{"type":"object"}}]}`)
+	chatResponse := []byte(`{"id":"chat_1","object":"chat.completion","created":1710000000,"choices":[{"index":0,"message":{"role":"assistant","tool_calls":[{"id":"ts_1","type":"function","function":{"name":"tool_search","arguments":"{bad"}}]},"finish_reason":"tool_calls"}]}`)
+	if _, err := ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStreamWithError(context.Background(), "gpt-5.4", request, request, chatResponse, nil); err == nil || !strings.Contains(err.Error(), "tool_search_call") {
+		t.Fatalf("expected invalid search arguments error, got %v", err)
+	}
+	if out := ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(context.Background(), "gpt-5.4", request, request, chatResponse, nil); len(out) != 0 {
+		t.Fatalf("legacy converter exposed an invalid completed response: %s", out)
+	}
+}
+
+func TestToolSearchResponseStreamRejectsInvalidArgumentsWithoutTerminalEvents(t *testing.T) {
+	request := []byte(`{"model":"gpt-5.4","tools":[{"type":"tool_search","execution":"client","parameters":{"type":"object"}}]}`)
+	first := []byte(`data: {"id":"chat_1","object":"chat.completion.chunk","created":1710000000,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"ts_1","type":"function","function":{"name":"tool_search","arguments":"{bad"}}]},"finish_reason":"tool_calls"}]}`)
+	done := []byte(`data: [DONE]`)
+	var state any
+	chunks, err := ConvertOpenAIChatCompletionsResponseToOpenAIResponsesWithError(context.Background(), "gpt-5.4", request, request, first, &state)
+	if err == nil || !strings.Contains(err.Error(), "tool_search_call") {
+		t.Fatalf("expected invalid streamed search arguments error, got chunks=%q err=%v", chunks, err)
+	}
+	if len(chunks) != 0 {
+		t.Fatalf("invalid streamed search call emitted terminal chunks: %q", chunks)
+	}
+	if _, err = ConvertOpenAIChatCompletionsResponseToOpenAIResponsesWithError(context.Background(), "gpt-5.4", request, request, done, &state); err == nil {
+		t.Fatal("expected the failed stream state to reject subsequent [DONE]")
+	}
+}
+
+func TestToolSearchResponsePreservesOrdinaryFunctionCallArguments(t *testing.T) {
+	request := []byte(`{"model":"gpt-5.4","tools":[{"type":"function","name":"lookup","parameters":{"type":"object"}}]}`)
+	chatResponse := []byte(`{"id":"chat_1","object":"chat.completion","created":1710000000,"choices":[{"index":0,"message":{"role":"assistant","tool_calls":[{"id":"call_1","type":"function","function":{"name":"lookup","arguments":"{bad"}}]},"finish_reason":"tool_calls"}]}`)
+	out := ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(context.Background(), "gpt-5.4", request, request, chatResponse, nil)
+	item := gjson.ParseBytes(out).Get("output.0")
+	if item.Get("type").String() != "function_call" || item.Get("arguments").String() != "{bad" {
+		t.Fatalf("ordinary function call behavior changed: %s", out)
+	}
+}
+
+func TestToolSearchResponseStreamRestoresSearchCall(t *testing.T) {
+	request := []byte(`{"model":"gpt-5.4","tools":[{"type":"tool_search","execution":"client","parameters":{"type":"object"}}]}`)
+	chunks := [][]byte{
+		[]byte(`{"id":"chat_1","object":"chat.completion.chunk","created":1710000000,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"ts_1","type":"function","function":{"arguments":"{\"goal\":\"shipping\"}"}}]},"finish_reason":null}]}`),
+		[]byte(`{"id":"chat_1","object":"chat.completion.chunk","created":1710000000,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"name":"tool_search"}}]},"finish_reason":"tool_calls"}]}`),
+		[]byte(`[DONE]`),
+	}
+	var state any
+	var events []gjson.Result
+	for _, chunk := range chunks {
+		for _, event := range ConvertOpenAIChatCompletionsResponseToOpenAIResponses(context.Background(), "gpt-5.4", request, request, chunk, &state) {
+			_, data := parseOpenAIResponsesSSEEvent(t, event)
+			events = append(events, data)
+		}
+	}
+	var added, done, completed bool
+	for _, event := range events {
+		switch event.Get("type").String() {
+		case "response.output_item.added":
+			if event.Get("item.type").String() == "tool_search_call" {
+				added = true
+			}
+		case "response.output_item.done":
+			if event.Get("item.type").String() == "tool_search_call" {
+				done = true
+				if got := event.Get("item.arguments.goal").String(); got != "shipping" {
+					t.Fatalf("unexpected streamed arguments %s", event.Get("item.arguments").Raw)
+				}
+			}
+		case "response.completed":
+			completed = true
+			if got := event.Get("response.output.0.type").String(); got != "tool_search_call" {
+				t.Fatalf("unexpected completed item %q", got)
+			}
+		}
+	}
+	if !added || !done || !completed {
+		t.Fatalf("missing search stream lifecycle events: added=%v done=%v completed=%v", added, done, completed)
+	}
+}

--- a/internal/protocol/cliproxy/openai/openai/responses/openai_openai-responses_tools.go
+++ b/internal/protocol/cliproxy/openai/openai/responses/openai_openai-responses_tools.go
@@ -79,7 +79,13 @@ func walkResponsesToolDeclarations(root gjson.Result, visit func(responsesToolDe
 	scan(root.Get("tools"))
 	if input := root.Get("input"); input.Exists() && input.IsArray() {
 		input.ForEach(func(_, item gjson.Result) bool {
-			if item.Get("type").String() == "additional_tools" {
+			switch item.Get("type").String() {
+			case "additional_tools":
+				scan(item.Get("tools"))
+			case "tool_search_output":
+				// Client-executed tool search returns the declarations that
+				// were loaded. They participate in the same flattened tool
+				// namespace as request-level declarations.
 				scan(item.Get("tools"))
 			}
 			return proceed
@@ -100,6 +106,29 @@ func walkResponsesToolDeclarations(root gjson.Result, visit func(responsesToolDe
 func mergeResponsesRequestChatTools(root gjson.Result) [][]byte {
 	var merged [][]byte
 	seenToolNames := make(map[string]struct{})
+	hasSearchDeclaration := false
+	// A client-executed tool_search is exposed to Chat Completions as one
+	// reserved ordinary function. Its call and output are translated back to
+	// Responses tool_search items by the response converter. Emit it before
+	// ordinary declarations so the request-level declaration keeps its
+	// canonical leading position when present.
+	walkResponsesToolSearchDeclarations(root, func(declaration responsesToolSearchDeclaration) bool {
+		hasSearchDeclaration = true
+		name := responsesChatToolSearchFunctionName
+		if _, duplicate := seenToolNames[name]; duplicate {
+			return true
+		}
+		chatTool := convertResponsesToolSearchToOpenAIChat(declaration.tool, name)
+		seenToolNames[name] = struct{}{}
+		merged = append(merged, chatTool)
+		return true
+	})
+	if !hasSearchDeclaration && responsesRequestHasToolSearch(root) {
+		// A complete replay may omit the original search declaration. Keep
+		// the reserved function available for its paired search history.
+		seenToolNames[responsesChatToolSearchFunctionName] = struct{}{}
+		merged = append(merged, convertResponsesToolSearchToOpenAIChat(gjson.Result{}, responsesChatToolSearchFunctionName))
+	}
 	walkResponsesToolDeclarations(root, func(declaration responsesToolDeclaration) bool {
 		if _, duplicate := seenToolNames[declaration.chatName]; duplicate {
 			return true
@@ -115,6 +144,18 @@ func mergeResponsesRequestChatTools(root gjson.Result) [][]byte {
 		return true
 	})
 	return merged
+}
+
+func convertResponsesToolSearchToOpenAIChat(tool gjson.Result, overrideName string) []byte {
+	chatTool := []byte(`{"type":"function","function":{"name":"","description":"","parameters":{"type":"object"}}}`)
+	chatTool, _ = sjson.SetBytes(chatTool, "function.name", overrideName)
+	if description := responsesToolDescription(tool); description != "" {
+		chatTool, _ = sjson.SetBytes(chatTool, "function.description", description)
+	}
+	if parameters := responsesToolParameters(tool); parameters.Exists() {
+		chatTool, _ = sjson.SetRawBytes(chatTool, "function.parameters", []byte(parameters.Raw))
+	}
+	return chatTool
 }
 
 // convertResponsesCustomToolToOpenAIChat maps a Responses freeform ("custom")


### PR DESCRIPTION
Closes #144

## 问题与修复

客户端在 Responses 请求中回传 `tool_search_output` 后，OpenAI Chat Completions bridge 会拒绝该输入类型，加载到的 namespace 工具也无法完整参与后续调用。本次转换保留 search call/output 的配对历史、动态工具声明和 namespace，支持流式及非流式往返；缺少配对历史或搜索参数不是合法 JSON object 时明确返回转换错误。

同一组代理兼容性修复还包括：

- 识别上游 `Could not decrypt ... encrypted_content` 的实际错误格式。恢复重试只移除不可复用的加密 reasoning，保留 compaction、普通消息和工具历史；没有保留历史时不重试。
- 根据 OpenCode Go 端点识别渠道并提供稳定的 `x-opencode-session`，保留显式会话头，同时覆盖代理和管理员测试请求。
- 为异常流补充上游最后读取、下游实际写入及 Flush 的时序和字节统计，包括部分写入后报错。保留已有 SSE framing、499、冷却和重试行为。

基于 `master` 的 `8fe6d59` 整理，未引入本地部署名称、模型专用请求改写、运行凭据或数据库。

## 验证

- 协议定向测试（`-tags sonic`）：通过。
- `make verify-web`：247 项通过。
- 后端回归：`CGO_ENABLED=0 go test -trimpath -tags sonic ./internal/... -count=1`；更新旧 WebSocket 测试的 compaction 预期后，`./internal/app` 全包复跑通过（40.133 秒），其余包在全量运行中通过。
- `golangci-lint v2.13.0 run --timeout=10m`：0 issues。
- `make build`：通过。

额外环境验证（基于原本地部署候选，不替代本 PR 分支的回归）：一次合成路由探针中，13 个配置路由均返回 HTTP 200，部分依赖回退渠道。工具搜索、Responses/Chat 工具回传探针的首轮被主渠道额度耗尽（403）和备用渠道服务过载（503）阻断，未完成真实上游往返。相关行为由本地转换器和代理 mock 回归覆盖，外部验证仍待上游恢复。

SSE 改动用于故障定位，不宣称已修复上游提前 EOF 的具体网络根因。
