### PR TITLE
fix(proxy): keep cooldown fallback within token channel limits (#147)

### DIFF
--- a/internal/app/proxy_handler.go
+++ b/internal/app/proxy_handler.go
@@ -415,6 +415,7 @@ func (s *Server) HandleProxyRequest(c *gin.Context) {
 		ctx, cancel = context.WithTimeout(ctx, timeout)
 		defer cancel()
 	}
+	ctx = withChannelRestrictionToken(ctx, tokenHashStr)
 
 	var executionSession *responsesExecutionSession
 	var routingSession *responsesExecutionSession

--- a/internal/app/proxy_responses_websocket.go
+++ b/internal/app/proxy_responses_websocket.go
@@ -444,6 +444,7 @@ func (s *Server) executeResponsesWebsocketTurn(
 			return responsesWebsocketTurnResult{}, errors.New("token cost limit exceeded")
 		}
 	}
+	ctx = withChannelRestrictionToken(ctx, tokenHashString)
 
 	candidates, err := s.selectCandidatesByModelAndClientProtocol(ctx, modelName, string(protocol.Codex))
 	if err == nil {

--- a/internal/app/selector_cooldown.go
+++ b/internal/app/selector_cooldown.go
@@ -12,6 +12,23 @@ import (
 	"ccLoad/internal/util"
 )
 
+type channelRestrictionTokenContextKey struct{}
+
+func withChannelRestrictionToken(ctx context.Context, tokenHash string) context.Context {
+	if ctx == nil || tokenHash == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, channelRestrictionTokenContextKey{}, tokenHash)
+}
+
+func channelRestrictionTokenFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	tokenHash, _ := ctx.Value(channelRestrictionTokenContextKey{}).(string)
+	return tokenHash
+}
+
 // filterCooldownChannels 过滤冷却中的渠道
 //
 // [IMPORTANT] 冷却状态优先级：**最高优先级**，必须在健康度排序前执行
@@ -38,6 +55,18 @@ func (s *Server) filterCooldownChannelsStrict(ctx context.Context, channels []*m
 func (s *Server) filterCooldownChannelsInternal(ctx context.Context, channels []*modelpkg.Config, requestModel, requestProtocol string, allowAllCooledFallback bool) ([]*modelpkg.Config, error) {
 	if len(channels) == 0 {
 		return channels, nil
+	}
+
+	// Token 渠道限制是路由边界，必须在全冷却兜底选择之前收窄候选集合。
+	// 限制后为空时保留原候选，让调用方现有的末端过滤继续返回 403。
+	if tokenHash := channelRestrictionTokenFromContext(ctx); tokenHash != "" && s.authService != nil {
+		filtered, restricted := s.authService.FilterAllowedChannels(tokenHash, channels)
+		if restricted {
+			if len(filtered) == 0 {
+				return channels, nil
+			}
+			channels = filtered
+		}
 	}
 
 	now := time.Now()


### PR DESCRIPTION
## Summary

Fixes #147.

When all candidate channels are in cooldown, the cooldown fallback could select the earliest recovering channel before applying the API token's channel restriction. An out-of-scope channel could therefore win the fallback comparison, leaving no usable candidate after the final permission filter.

This change applies the existing token channel restriction before cooldown filtering and fallback selection.

## Behavior

- `allow` mode: fallback only considers channels in the allowlist.
- `deny` mode: fallback excludes channels in the denylist.
- Empty channel restriction: behavior remains unchanged and all eligible global candidates are considered.
- If all in-scope channels are cooled down, the earliest recovering in-scope channel is selected.
- `cooldown_fallback_enabled` behavior is unchanged.
- No new configuration, schema, or API fields are introduced.

## Scope

- Minimal production-only change.
- No new configuration option.
- No new test file or broad refactoring.

## Verification

- `go test ./...`
- `git diff --check`