### PR TITLE
feat(opencode): show Go subscription usage on API-key channels

### DIFF
--- a/internal/app/admin_oauth_usage.go
+++ b/internal/app/admin_oauth_usage.go
@@ -1577,6 +1577,10 @@ func (s *Server) refreshChannelUsage(ctx context.Context, channelID int64) (stri
 		return "", nil, nil, errOAuthUsageChannelNotFound
 	}
 	if cfg.GetAuthType() == model.AuthTypeAPIKey {
+		if isOpenCodeChannel(cfg) {
+			usage, err := s.refreshOAuthUsage(ctx, channelID)
+			return "oauth", usage, nil, err
+		}
 		if s.channelManagement == nil {
 			return "management", nil, nil, errChannelManagementProviderUnavailable
 		}
@@ -1596,6 +1600,9 @@ func (s *Server) persistOAuthUsage(
 ) (*oauthUsageSummary, error) {
 	if s == nil || s.store == nil || cfg == nil || summary == nil {
 		return nil, errors.New("OAuth usage persistence is unavailable")
+	}
+	if cfg.GetAuthType() == model.AuthTypeAPIKey {
+		return summary, nil
 	}
 
 	for {
@@ -1912,6 +1919,8 @@ func (s *Server) oauthUsageSummary(ctx context.Context, cfg *model.Config) (*oau
 			}
 		}
 		return nil, errors.New("usage: Cursor session token was rejected")
+	case isOpenCodeChannel(cfg):
+		return s.requestOpenCodeGoUsage(ctx, cfg)
 	case cfg.UsesZedOAuth():
 		if s.zedCredentials == nil {
 			return nil, errZedUsageManagerUnavailable

--- a/internal/app/opencode_usage.go
+++ b/internal/app/opencode_usage.go
@@ -59,7 +59,7 @@ func (s *Server) requestOpenCodeGoUsage(ctx context.Context, cfg *model.Config) 
 	if err != nil {
 		return nil, &oauthUsageRequestError{provider: opencodeGoUsageProvider}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	body, err := io.ReadAll(io.LimitReader(resp.Body, maxOAuthUsageResponseBytes+1))
 	if err != nil {
 		return nil, fmt.Errorf("usage: read OpenCode Go response: %w", err)

--- a/internal/app/opencode_usage.go
+++ b/internal/app/opencode_usage.go
@@ -1,0 +1,157 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"ccLoad/internal/model"
+)
+
+const (
+	opencodeGoUsageProvider  = "opencode-go"
+	opencodeGoUsagePath      = "/zen/go/v1/usage"
+	opencodeGoUsageUserAgent = "opencode/1.0"
+	opencodeGoRollingSeconds = 5 * 60 * 60
+	opencodeGoWeeklySeconds  = 7 * 24 * 60 * 60
+)
+
+type opencodeGoUsageWindow struct {
+	Status   string  `json:"status"`
+	Percent  float64 `json:"percent"`
+	ResetsAt string  `json:"resetsAt"`
+}
+
+type opencodeGoUsagePayload struct {
+	Usage struct {
+		Rolling *opencodeGoUsageWindow `json:"rolling"`
+		Weekly  *opencodeGoUsageWindow `json:"weekly"`
+		Monthly *opencodeGoUsageWindow `json:"monthly"`
+	} `json:"usage"`
+}
+
+func (s *Server) requestOpenCodeGoUsage(ctx context.Context, cfg *model.Config) (*oauthUsageSummary, error) {
+	if s == nil || s.store == nil {
+		return nil, errors.New("usage: OpenCode Go store is unavailable")
+	}
+	keys, err := s.store.GetAPIKeys(ctx, cfg.ID)
+	if err != nil {
+		return nil, fmt.Errorf("usage: load OpenCode Go API keys: %w", err)
+	}
+	apiKey := firstOpenCodeGoAPIKey(keys)
+	if apiKey == "" {
+		return nil, errors.New("usage: OpenCode Go channel has no API key")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://"+opencodeHost+opencodeGoUsagePath, nil)
+	if err != nil {
+		return nil, fmt.Errorf("usage: build OpenCode Go request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", opencodeGoUsageUserAgent)
+
+	resp, err := s.getClientForChannel(cfg).Do(req)
+	if err != nil {
+		return nil, &oauthUsageRequestError{provider: opencodeGoUsageProvider}
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxOAuthUsageResponseBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("usage: read OpenCode Go response: %w", err)
+	}
+	if len(body) > maxOAuthUsageResponseBytes {
+		return nil, errors.New("usage: OpenCode Go response exceeds size limit")
+	}
+	if resp.StatusCode != http.StatusOK {
+		if trimmed := strings.TrimSpace(string(body)); trimmed != "" {
+			return nil, errors.New(trimmed)
+		}
+		return nil, fmt.Errorf("usage: OpenCode Go endpoint returned HTTP %d", resp.StatusCode)
+	}
+	var payload opencodeGoUsagePayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, fmt.Errorf("usage: decode OpenCode Go response: %w", err)
+	}
+	return normalizeOpenCodeGoUsage(&payload)
+}
+
+func firstOpenCodeGoAPIKey(keys []*model.APIKey) string {
+	for _, key := range keys {
+		if key == nil || key.Disabled {
+			continue
+		}
+		if apiKey := strings.TrimSpace(key.APIKey); apiKey != "" {
+			return apiKey
+		}
+	}
+	return ""
+}
+
+func normalizeOpenCodeGoUsage(payload *opencodeGoUsagePayload) (*oauthUsageSummary, error) {
+	if payload == nil {
+		return nil, errors.New("usage: OpenCode Go response is empty")
+	}
+	summary := &oauthUsageSummary{
+		Provider: opencodeGoUsageProvider,
+		PlanType: "go",
+		Windows:  make([]oauthUsageWindow, 0, 3),
+	}
+	type mappedWindow struct {
+		name          string
+		kind          string
+		windowSeconds int64
+		raw           *opencodeGoUsageWindow
+	}
+	for _, item := range []mappedWindow{
+		{name: "five_hour", kind: "rolling", windowSeconds: opencodeGoRollingSeconds, raw: payload.Usage.Rolling},
+		{name: "weekly", kind: "weekly", windowSeconds: opencodeGoWeeklySeconds, raw: payload.Usage.Weekly},
+		{name: "monthly", kind: "monthly", raw: payload.Usage.Monthly},
+	} {
+		if item.raw == nil {
+			continue
+		}
+		usedPercent := min(max(item.raw.Percent, 0), 100)
+		resetAt := parseOpenCodeGoResetAt(item.raw.ResetsAt)
+		windowSeconds := item.windowSeconds
+		if item.kind == "monthly" && resetAt > 0 {
+			if remaining := resetAt - time.Now().UTC().Unix(); remaining > 0 {
+				windowSeconds = remaining
+			}
+		}
+		summary.Windows = append(summary.Windows, oauthUsageWindow{
+			LimitName:          item.name,
+			Kind:               item.kind,
+			UsedPercent:        usedPercent,
+			RemainingPercent:   100 - usedPercent,
+			LimitWindowSeconds: windowSeconds,
+			ResetAt:            resetAt,
+		})
+		if status := strings.TrimSpace(item.raw.Status); status != "" && !strings.EqualFold(status, "ok") {
+			summary.EntitlementStatus = status
+		}
+	}
+	if len(summary.Windows) == 0 {
+		return nil, errors.New("usage: OpenCode Go response has no quota windows")
+	}
+	return summary, nil
+}
+
+func parseOpenCodeGoResetAt(raw string) int64 {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		parsed, err = time.Parse(time.RFC3339, raw)
+	}
+	if err != nil {
+		return 0
+	}
+	return parsed.UTC().Unix()
+}

--- a/internal/app/opencode_usage_test.go
+++ b/internal/app/opencode_usage_test.go
@@ -16,15 +16,14 @@ import (
 
 func TestNormalizeOpenCodeGoUsageProjectsOfficialWindows(t *testing.T) {
 	t.Parallel()
-	summary, err := normalizeOpenCodeGoUsage(&opencodeGoUsagePayload{})
-	if err == nil {
+	if _, err := normalizeOpenCodeGoUsage(&opencodeGoUsagePayload{}); err == nil {
 		t.Fatal("normalizeOpenCodeGoUsage() expected an error for empty windows")
 	}
 	payload := &opencodeGoUsagePayload{}
 	payload.Usage.Rolling = &opencodeGoUsageWindow{Status: "ok", Percent: 19.5, ResetsAt: "2026-09-12T06:38:42.393Z"}
 	payload.Usage.Weekly = &opencodeGoUsageWindow{Status: "ok", Percent: 29.7, ResetsAt: "2026-09-14T00:00:00.393Z"}
 	payload.Usage.Monthly = &opencodeGoUsageWindow{Status: "ok", Percent: 25, ResetsAt: "2026-10-11T01:58:47.393Z"}
-	summary, err = normalizeOpenCodeGoUsage(payload)
+	summary, err := normalizeOpenCodeGoUsage(payload)
 	if err != nil {
 		t.Fatalf("normalizeOpenCodeGoUsage() error = %v", err)
 	}
@@ -51,7 +50,7 @@ func TestHandleOAuthUsageReturnsOpenCodeGoQuotaWithoutLeakingKey(t *testing.T) {
 	ctx := context.Background()
 	channel, err := store.CreateConfig(ctx, &model.Config{
 		Name: "OpenCode Go", AuthType: model.AuthTypeAPIKey,
-		URLs: model.ChannelURLs{{URL: "https://opencode.ai/zen/go"}},
+		URLs:    model.ChannelURLs{{URL: "https://opencode.ai/zen/go"}},
 		Enabled: true, ModelEntries: []model.ModelEntry{{Model: "glm-5.3-flash"}},
 	})
 	if err != nil {
@@ -110,7 +109,7 @@ func TestHandleOAuthUsageRejectsNonOpenCodeAPIKeyChannel(t *testing.T) {
 	defer cleanup()
 	channel, err := store.CreateConfig(context.Background(), &model.Config{
 		Name: "generic", AuthType: model.AuthTypeAPIKey,
-		URLs: model.ChannelURLs{{URL: "https://example.com"}},
+		URLs:    model.ChannelURLs{{URL: "https://example.com"}},
 		Enabled: true, ModelEntries: []model.ModelEntry{{Model: "m"}},
 	})
 	if err != nil {

--- a/internal/app/opencode_usage_test.go
+++ b/internal/app/opencode_usage_test.go
@@ -1,0 +1,125 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"ccLoad/internal/model"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestNormalizeOpenCodeGoUsageProjectsOfficialWindows(t *testing.T) {
+	t.Parallel()
+	summary, err := normalizeOpenCodeGoUsage(&opencodeGoUsagePayload{})
+	if err == nil {
+		t.Fatal("normalizeOpenCodeGoUsage() expected an error for empty windows")
+	}
+	payload := &opencodeGoUsagePayload{}
+	payload.Usage.Rolling = &opencodeGoUsageWindow{Status: "ok", Percent: 19.5, ResetsAt: "2026-09-12T06:38:42.393Z"}
+	payload.Usage.Weekly = &opencodeGoUsageWindow{Status: "ok", Percent: 29.7, ResetsAt: "2026-09-14T00:00:00.393Z"}
+	payload.Usage.Monthly = &opencodeGoUsageWindow{Status: "ok", Percent: 25, ResetsAt: "2026-10-11T01:58:47.393Z"}
+	summary, err = normalizeOpenCodeGoUsage(payload)
+	if err != nil {
+		t.Fatalf("normalizeOpenCodeGoUsage() error = %v", err)
+	}
+	if summary.Provider != opencodeGoUsageProvider || summary.PlanType != "go" || len(summary.Windows) != 3 {
+		t.Fatalf("summary = %#v", summary)
+	}
+	if summary.Windows[0].LimitName != "five_hour" || summary.Windows[0].Kind != "rolling" ||
+		summary.Windows[0].UsedPercent != 19.5 || summary.Windows[0].RemainingPercent != 80.5 ||
+		summary.Windows[0].LimitWindowSeconds != opencodeGoRollingSeconds ||
+		summary.Windows[0].ResetAt != time.Date(2026, time.September, 12, 6, 38, 42, 393000000, time.UTC).Unix() {
+		t.Fatalf("rolling window = %#v", summary.Windows[0])
+	}
+	if summary.Windows[1].LimitName != "weekly" || summary.Windows[1].UsedPercent != 29.7 {
+		t.Fatalf("weekly window = %#v", summary.Windows[1])
+	}
+	if summary.Windows[2].LimitName != "monthly" || summary.Windows[2].UsedPercent != 25 {
+		t.Fatalf("monthly window = %#v", summary.Windows[2])
+	}
+}
+
+func TestHandleOAuthUsageReturnsOpenCodeGoQuotaWithoutLeakingKey(t *testing.T) {
+	server, store, cleanup := setupAdminTestServer(t)
+	defer cleanup()
+	ctx := context.Background()
+	channel, err := store.CreateConfig(ctx, &model.Config{
+		Name: "OpenCode Go", AuthType: model.AuthTypeAPIKey,
+		URLs: model.ChannelURLs{{URL: "https://opencode.ai/zen/go"}},
+		Enabled: true, ModelEntries: []model.ModelEntry{{Model: "glm-5.3-flash"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CreateAPIKeysBatch(ctx, []*model.APIKey{{
+		ChannelID: channel.ID, APIKey: "sk-opencode-secret",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	var sawUsageRequest bool
+	server.client = &http.Client{Transport: oauthUsageRoundTripper(func(request *http.Request) (*http.Response, error) {
+		if request.URL.Host != opencodeHost || request.URL.Path != opencodeGoUsagePath {
+			t.Fatalf("usage URL = %s", request.URL)
+		}
+		if got := request.Header.Get("Authorization"); got != "Bearer sk-opencode-secret" {
+			t.Errorf("Authorization = %q", got)
+		}
+		if got := request.Header.Get("User-Agent"); got != opencodeGoUsageUserAgent {
+			t.Errorf("User-Agent = %q", got)
+		}
+		sawUsageRequest = true
+		body := `{"usage":{"rolling":{"status":"ok","percent":12.5,"resetsAt":"2026-09-12T06:38:42Z"},"weekly":{"status":"ok","percent":40,"resetsAt":"2026-09-14T00:00:00Z"},"monthly":{"status":"ok","percent":8,"resetsAt":"2026-10-11T01:58:47Z"}}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    request,
+		}, nil
+	})}
+
+	path := fmt.Sprintf("/admin/channels/%d/oauth-usage", channel.ID)
+	c, w := newTestContext(t, newRequest(http.MethodPost, path, nil))
+	c.Params = gin.Params{{Key: "id", Value: fmt.Sprintf("%d", channel.ID)}}
+	server.HandleOAuthUsage(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("usage status=%d body=%s", w.Code, w.Body.String())
+	}
+	if !sawUsageRequest {
+		t.Fatal("OpenCode Go usage endpoint was not called")
+	}
+	if strings.Contains(w.Body.String(), "sk-opencode-secret") {
+		t.Fatalf("usage response leaked credential: %s", w.Body.String())
+	}
+	response := mustParseAPIResponse[oauthUsageSummary](t, w.Body.Bytes())
+	if response.Data.Provider != opencodeGoUsageProvider || response.Data.PlanType != "go" || len(response.Data.Windows) != 3 {
+		t.Fatalf("usage summary = %#v", response.Data)
+	}
+	if response.Data.Windows[0].UsedPercent != 12.5 || response.Data.Windows[1].UsedPercent != 40 {
+		t.Fatalf("windows = %#v", response.Data.Windows)
+	}
+}
+
+func TestHandleOAuthUsageRejectsNonOpenCodeAPIKeyChannel(t *testing.T) {
+	server, store, cleanup := setupAdminTestServer(t)
+	defer cleanup()
+	channel, err := store.CreateConfig(context.Background(), &model.Config{
+		Name: "generic", AuthType: model.AuthTypeAPIKey,
+		URLs: model.ChannelURLs{{URL: "https://example.com"}},
+		Enabled: true, ModelEntries: []model.ModelEntry{{Model: "m"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, w := newTestContext(t, newRequest(http.MethodPost, fmt.Sprintf("/admin/channels/%d/oauth-usage", channel.ID), nil))
+	c.Params = gin.Params{{Key: "id", Value: fmt.Sprintf("%d", channel.ID)}}
+	server.HandleOAuthUsage(c)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+}

--- a/web/assets/js/channels-codex-auth.js
+++ b/web/assets/js/channels-codex-auth.js
@@ -2427,7 +2427,10 @@ async function batchRefreshSelectedOAuthUsage(fetcher = fetchWithAuth) {
   const channelList = typeof channels !== 'undefined' && Array.isArray(channels) ? channels : [];
   const eligibleIDs = selectedIDs.filter(id => {
     const channel = channelList.find(item => Number(item.id) === id);
-    return typeof channelShowsOAuthUsage === 'function' ? channelShowsOAuthUsage(channel) : false;
+    if (typeof channelShowsOAuthUsage === 'function') {
+      return channelShowsOAuthUsage(channel);
+    }
+    return channel && ['codex_oauth', 'antigravity_oauth', 'xai_oauth', 'anthropic_oauth', 'zai_oauth', 'cursor_oauth', 'zed_oauth', 'codebuddy_oauth'].includes(channel.auth_type);
   });
   const skipped = selectedIDs.length - eligibleIDs.length;
   if (eligibleIDs.length === 0) {

--- a/web/assets/js/channels-codex-auth.js
+++ b/web/assets/js/channels-codex-auth.js
@@ -2427,7 +2427,7 @@ async function batchRefreshSelectedOAuthUsage(fetcher = fetchWithAuth) {
   const channelList = typeof channels !== 'undefined' && Array.isArray(channels) ? channels : [];
   const eligibleIDs = selectedIDs.filter(id => {
     const channel = channelList.find(item => Number(item.id) === id);
-    return channel && ['codex_oauth', 'antigravity_oauth', 'xai_oauth', 'anthropic_oauth', 'zai_oauth', 'cursor_oauth', 'zed_oauth', 'codebuddy_oauth'].includes(channel.auth_type);
+    return typeof channelShowsOAuthUsage === 'function' ? channelShowsOAuthUsage(channel) : false;
   });
   const skipped = selectedIDs.length - eligibleIDs.length;
   if (eligibleIDs.length === 0) {

--- a/web/assets/js/channels-render.js
+++ b/web/assets/js/channels-render.js
@@ -29,6 +29,43 @@ function escapeChannelRefreshText(value) {
   }[c]));
 }
 
+const OAUTH_USAGE_AUTH_TYPES = [
+  'codex_oauth',
+  'antigravity_oauth',
+  'xai_oauth',
+  'anthropic_oauth',
+  'zai_oauth',
+  'cursor_oauth',
+  'zed_oauth',
+  'codebuddy_oauth'
+];
+
+function isOpenCodeGoEndpoint(raw) {
+  const text = String(raw || '').trim().replace(/#$/, '');
+  if (!text) return false;
+  let parsed;
+  try {
+    parsed = new URL(text);
+  } catch (_) {
+    return false;
+  }
+  if (parsed.protocol !== 'https:' || parsed.hostname !== 'opencode.ai' || parsed.port || parsed.username || parsed.password || parsed.hash) {
+    return false;
+  }
+  const path = parsed.pathname || '';
+  if (path.split('/').some(segment => segment === '.' || segment === '..')) return false;
+  return path === '/zen/go' || path.startsWith('/zen/go/');
+}
+
+function isOpenCodeGoChannel(channel) {
+  const entries = Array.isArray(channel?.urls) ? channel.urls : [];
+  return entries.some(entry => isOpenCodeGoEndpoint(typeof entry === 'string' ? entry : entry?.url));
+}
+
+function channelShowsOAuthUsage(channel) {
+  return OAUTH_USAGE_AUTH_TYPES.includes(channel?.auth_type) || isOpenCodeGoChannel(channel);
+}
+
 // Codex plan_type → 用户可读标签；未登记的值原样返回。
 function codexPlanLabel(rawPlanType) {
   const key = String(rawPlanType || '').toLowerCase().replace(/[^a-z0-9]+/g, '_');
@@ -644,7 +681,7 @@ function formatOAuthUsageLimitName(limitName) {
   if (isCodexSparkLimitName(limitName)) return 'Spark';
   if (normalized === 'gemini models') return 'Gemini';
   // Z.ai 的 token 窗口只有时长有信息量，时长已单独渲染，避免出现「five_hour 5小时」。
-  if (normalized === 'five_hour' || normalized === 'weekly') return '';
+  if (normalized === 'five_hour' || normalized === 'weekly' || normalized === 'monthly' || normalized === 'rolling') return '';
   if (normalized === 'mcp_limit') return 'MCP';
   if (normalized === 'included') return window.t('channels.cursor.usageMonthlyLimit');
   if (normalized === 'api') return window.t('channels.cursor.usageOtherModels');
@@ -939,7 +976,7 @@ function buildCodeBuddyCreditsHtml(credits) {
 }
 
 function buildOAuthUsageStatusHtml(channel) {
-  if (!['codex_oauth', 'antigravity_oauth', 'xai_oauth', 'anthropic_oauth', 'zai_oauth', 'cursor_oauth', 'zed_oauth', 'codebuddy_oauth'].includes(channel?.auth_type) ||
+  if (!channelShowsOAuthUsage(channel) ||
       (typeof isTokenChannelsReadOnly === 'function' && isTokenChannelsReadOnly())) {
     return '';
   }
@@ -1625,6 +1662,8 @@ if (typeof module !== 'undefined' && module.exports) {
     codexPlanLabel,
     buildOAuthUsageStatusHtml,
     buildManagementAccountStatusHtml,
-    formatCooldownRecoveryTime
+    formatCooldownRecoveryTime,
+    isOpenCodeGoChannel,
+    channelShowsOAuthUsage
   };
 }

--- a/web/assets/js/channels-render.test.js
+++ b/web/assets/js/channels-render.test.js
@@ -4,7 +4,9 @@ const assert = require('node:assert/strict');
 const {
   buildOAuthPlanBadge,
   buildOAuthUsageStatusHtml,
-  buildManagementAccountStatusHtml
+  buildManagementAccountStatusHtml,
+  isOpenCodeGoChannel,
+  channelShowsOAuthUsage
 } = require('./channels-render.js');
 
 test('OAuth 额度刷新失败时格式化结构化错误并转义内容', () => {
@@ -136,6 +138,32 @@ test('CodeBuddy 额度工具栏提供独立的手动签到状态', () => {
 
     html = buildOAuthUsageStatusHtml({ id: 73, auth_type: 'codebuddy_oauth', codebuddy_international: true });
     assert.doesNotMatch(html, /data-action="checkin-codebuddy"/);
+  } finally {
+    global.window = previousWindow;
+    global.getOAuthUsageState = previousGetUsageState;
+    global.isTokenChannelsReadOnly = previousReadOnly;
+  }
+});
+
+test('OpenCode Go API Key 渠道显示额度工具栏', () => {
+  const previousWindow = global.window;
+  const previousGetUsageState = global.getOAuthUsageState;
+  const previousReadOnly = global.isTokenChannelsReadOnly;
+  global.window = { t: key => key === 'channels.oauth.usageRefresh' ? '刷新额度' : key };
+  global.getOAuthUsageState = () => null;
+  global.isTokenChannelsReadOnly = () => false;
+  try {
+    const channel = {
+      id: 4,
+      auth_type: 'api_key',
+      urls: [{ url: 'https://opencode.ai/zen/go' }]
+    };
+    assert.equal(isOpenCodeGoChannel(channel), true);
+    assert.equal(channelShowsOAuthUsage(channel), true);
+    assert.equal(isOpenCodeGoChannel({ auth_type: 'api_key', urls: [{ url: 'https://example.com' }] }), false);
+    const html = buildOAuthUsageStatusHtml(channel);
+    assert.match(html, /data-action="refresh-oauth-usage"/);
+    assert.match(html, /data-channel-id="4"/);
   } finally {
     global.window = previousWindow;
     global.getOAuthUsageState = previousGetUsageState;


### PR DESCRIPTION
## Summary

OpenCode Go (`https://opencode.ai/zen/go`) is a **$10/month subscription**, not Zen pay-as-you-go. Official usage is:

```http
GET https://opencode.ai/zen/go/v1/usage
Authorization: Bearer <Go API key>
User-Agent: opencode/1.0
```

```json
{
  "usage": {
    "rolling": { "status": "ok", "percent": 12.5, "resetsAt": "…" },
    "weekly":  { "status": "ok", "percent": 40, "resetsAt": "…" },
    "monthly": { "status": "ok", "percent": 8, "resetsAt": "…" }
  }
}
```

ccLoad already treats that host/path as OpenCode for `x-opencode-session`. Quota refresh still returned `channel does not use a supported OAuth provider` because these channels are `auth_type=api_key`.

This wires the official usage endpoint into the existing OAuth usage card for matching API-key channels (no new auth type, existing Go channels keep working).

## What this does **not** change

- OpenCode Zen prepaid balance (still no public API; dashboard scrape only).
- Inference routing, session headers, or Cloudflare fingerprinting beyond the usage GET User-Agent.
- OAuth credential persistence (API-key channels have no OAuth envelope).

## Files

| File | Change |
| --- | --- |
| `internal/app/opencode_usage.go` | fetch/normalize `/zen/go/v1/usage` |
| `internal/app/opencode_usage_test.go` | window mapping + admin handler |
| `internal/app/admin_oauth_usage.go` | recognize OpenCode Go API-key channels |
| `web/assets/js/channels-render.js` | show usage toolbar for `opencode.ai/zen/go` |
| `web/assets/js/channels-codex-auth.js` | batch refresh eligibility |

`allow_maintainer_edits` is on.